### PR TITLE
core_commands: use new show_room method etc

### DIFF
--- a/pynicotine/chatrooms.py
+++ b/pynicotine/chatrooms.py
@@ -69,11 +69,6 @@ class ChatRooms:
             self.queue.append(slskmessages.JoinPublicRoom())
 
         elif room not in self.joined_rooms:
-            if room not in self.server_rooms and room not in self.private_rooms:
-                log.add_chat(_(f"Creating new room {room}"))
-            else:
-                log.add_chat(_(f"Joining room {room}"))
-
             self.queue.append(slskmessages.JoinRoom(room, private))
             return
 

--- a/pynicotine/chatrooms.py
+++ b/pynicotine/chatrooms.py
@@ -102,15 +102,20 @@ class ChatRooms:
 
     def send_message(self, room, message):
 
-        event = self.core.pluginhandler.outgoing_public_chat_event(room, message)
-        if event is None:
-            return
+        room, message = self.core.pluginhandler.outgoing_public_chat_event(room, message)
 
-        room, message = event
+        if room is None or message is None:
+            return False
+
         message = self.core.privatechats.auto_replace(message)
+
+        if message == "":
+            return False
 
         self.queue.append(slskmessages.SayChatroom(room, message))
         self.core.pluginhandler.outgoing_public_chat_notification(room, message)
+
+        return True
 
     def create_private_room(self, room, owner=None, operators=None):
 

--- a/pynicotine/chatrooms.py
+++ b/pynicotine/chatrooms.py
@@ -79,21 +79,17 @@ class ChatRooms:
 
         if room == "Public ":
             self.queue.append(slskmessages.LeavePublicRoom())
+
         elif room in self.joined_rooms:
             log.add_chat(_(f"Leaving room {room}"))
             self.queue.append(slskmessages.LeaveRoom(room))
             self.joined_rooms.discard(room)
-            was_joined = True
-        else:
-            was_joined = False
 
         if room in self.config.sections["columns"]["chat_room"]:
             del self.config.sections["columns"]["chat_room"][room]
 
         if self.ui_callback:
             self.ui_callback.remove_room(room)
-
-        return was_joined
 
     def clear_messages(self, room):
         if self.ui_callback:

--- a/pynicotine/chatrooms.py
+++ b/pynicotine/chatrooms.py
@@ -79,10 +79,13 @@ class ChatRooms:
 
         if room == "Public ":
             self.queue.append(slskmessages.LeavePublicRoom())
-        else:
+        elif room in self.joined_rooms:
+            log.add_chat(_(f"Leaving room {room}"))
             self.queue.append(slskmessages.LeaveRoom(room))
-
-        self.joined_rooms.discard(room)
+            self.joined_rooms.discard(room)
+            was_joined = True
+        else:
+            was_joined = False
 
         if room in self.config.sections["columns"]["chat_room"]:
             del self.config.sections["columns"]["chat_room"][room]
@@ -90,7 +93,7 @@ class ChatRooms:
         if self.ui_callback:
             self.ui_callback.remove_room(room)
 
-        self.core.pluginhandler.leave_chatroom_notification(room)
+        return was_joined
 
     def clear_messages(self, room):
         if self.ui_callback:
@@ -199,6 +202,8 @@ class ChatRooms:
 
         if self.ui_callback:
             self.ui_callback.leave_room(msg)
+
+        self.core.pluginhandler.leave_chatroom_notification(msg.room)
 
     def get_user_status(self, msg):
         """ Server code: 7 """

--- a/pynicotine/chatrooms.py
+++ b/pynicotine/chatrooms.py
@@ -69,6 +69,11 @@ class ChatRooms:
             self.queue.append(slskmessages.JoinPublicRoom())
 
         elif room not in self.joined_rooms:
+            if room not in self.server_rooms and room not in self.private_rooms:
+                log.add_chat(_(f"Creating new room {room}"))
+            else:
+                log.add_chat(_(f"Joining room {room}"))
+
             self.queue.append(slskmessages.JoinRoom(room, private))
             return
 
@@ -190,6 +195,8 @@ class ChatRooms:
 
         if self.ui_callback:
             self.ui_callback.join_room(msg)
+
+        self.echo_message(msg.room, "Joined room %(room)s" % {"room": msg.room})
 
         self.core.pluginhandler.join_chatroom_notification(msg.room)
 

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -344,13 +344,6 @@ class ChatRooms(IconNotebook):
         if page is not None:
             page.ticker_remove(msg)
 
-    def clear_view(self, room):
-
-        page = self.pages.get(room)
-        if page is not None:
-            page.chat_view.on_clear_all_text()
-            page.activity_view.on_clear_all_text()
-
     def echo_message(self, room, text, message_type):
 
         page = self.pages.get(room)

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -157,12 +157,6 @@ class PrivateChats(IconNotebook):
         self.remove_page(page.container)
         del self.pages[user]
 
-    def clear_view(self, user):
-
-        page = self.pages.get(user)
-        if page is not None:
-            page.chat_view.on_clear_all_text()
-
     def echo_message(self, user, text, message_type):
 
         page = self.pages.get(user)

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -196,10 +196,10 @@ class Plugin(BasePlugin):
             return
 
         if command_type == "chatroom":
-            self.core.chatrooms.clear_view(source)
+            self.core.chatrooms.clear_messages(source)
 
         elif command_type == "private_chat":
-            self.core.privatechats.clear_view(source)
+            self.core.privatechats.clear_messages(source)
 
     def join_command(self, args, _command_type, _source):
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -182,11 +182,9 @@ class Plugin(BasePlugin):
 
     def _echo_missing_arg(self, arg):
         self.echo_message("Missing argument: %s" % arg)
-        return arg
 
     def _echo_unexpect_arg(self, arg):
         self.echo_message("Unexpected argument: %s" % arg)
-        return False
 
     def close_command(self, args, command_type, source):
 
@@ -198,14 +196,14 @@ class Plugin(BasePlugin):
         elif user:
             self.echo_message("Not messaging with user %s" % user)
         else:
-            return self._echo_missing_arg('[user]')
+            self._echo_missing_arg('[user]')
 
     def clear_command(self, args, command_type, source):
 
         if args:
-            return self._echo_unexpect_arg(args.split(" ", maxsplit=1)[0])
+            self._echo_unexpect_arg(args.split(" ", maxsplit=1)[0])
 
-        if command_type == "chatroom":
+        elif command_type == "chatroom":
             self.core.chatrooms.clear_messages(source)
 
         elif command_type == "private_chat":
@@ -229,10 +227,13 @@ class Plugin(BasePlugin):
         room = args if args else (source if command_type == "chatroom" else None)
 
         if not room:
-            return self._echo_missing_arg('[room]')
-
-        if not self.core.chatrooms.remove_room(room):
+            self._echo_missing_arg('[room]')
+        elif room not in self.core.chatrooms.joined_rooms:
             self.echo_message("Not joined in room %s" % room)
+        elif command_type != "chatroom" or room != source:
+            self.echo_message(_(f"Leaving room {room}"))
+
+        self.core.chatrooms.remove_room(room)
 
     def me_command(self, args, _command_type, _source):
         self.send_message("/me " + args)

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -26,16 +26,6 @@ class Plugin(BasePlugin):
         super().__init__(*args, **kwargs)
 
         commands = {
-            "help": {
-                "callbacks": {
-                    "chatroom": self.help_chatroom_command,
-                    "private_chat": self.help_private_chat_command,
-                    "cli": self.help_cli_command
-                },
-                "description": "Show commands",
-                "usage": ["[query]"],
-                "aliases": ["?"]
-            },
             "rescan": {
                 "callback": self.rescan_command,
                 "description": _("Rescan shares"),
@@ -53,62 +43,14 @@ class Plugin(BasePlugin):
                 "description": _("Toggle away status"),
                 "aliases": ["a"]
             },
-            "quit": {
-                "callbacks": {
-                    "chatroom": self.quit_program_chatroom_command,
-                    "private_chat": self.quit_program_private_chat_command,
-                    "cli": self.quit_program_command
-                },
-                "description": _("Quit Nicotine+"),
-                "usage": ["[force]"],
-                "aliases": ["q", "exit"]
-            }
         }
 
         chat_commands = {
-            "clear": {
-                "callbacks": {
-                    "chatroom": self.clear_chatroom_command,
-                    "private_chat": self.clear_private_chat_command,
-                },
-                "description": _("Clear chat window"),
-                "aliases": ["cl"],
-                "group": _("Chat")
-            },
-            "close": {
-                "callbacks": {
-                    "chatroom": self.close_other_chat_command,
-                    "private_chat": self.close_private_chat_command,
-                },
-                "description": _("Close private chat"),
-                "usage": ["[user]"],
-                "aliases": ["c"],
-                "group": _("Private Chat")
-            },
-            "ctcpversion": {
-                "callbacks": {
-                    "chatroom": self.ctcpversion_other_chat_command,
-                    "private_chat": self.ctcpversion_private_chat_command,
-                },
-                "description": _("Ask for a user's client version"),
-                "usage": ["[user]"],
-                "group": _("Client-To-Client Protocol")
-            },
             "join": {
                 "callback": self.join_chat_command,
                 "description": _("Join chat room"),
                 "usage": ["<room>"],
                 "aliases": ["j"],
-                "group": _("Chat Rooms")
-            },
-            "leave": {
-                "callbacks": {
-                    "chatroom": self.leave_chatroom_command,
-                    "private_chat": self.leave_other_chat_command,
-                },
-                "description": _("Leave chat room"),
-                "usage": ["[room]"],
-                "aliases": ["l"],
                 "group": _("Chat Rooms")
             },
             "me": {
@@ -135,10 +77,92 @@ class Plugin(BasePlugin):
                 "description": _("Say message in specified chat room"),
                 "usage": ["<room>", "<message..>"],
                 "group": _("Chat Rooms")
+            },
+            "quit": {
+                "callback": self.quit_program_chat_command,
+                "description": _("Quit Nicotine+"),
+                "usage": ["[force]"],
+                "aliases": ["q", "exit"]
             }
         }
 
+        chatroom_commands = {
+            "help": {
+                "callback": self.help_chatroom_command,
+                "description": "Show commands",
+                "usage": ["[query]"],
+                "aliases": ["?"]
+            },
+            "clear": {
+                "callback": self.clear_chatroom_command,
+                "description": _("Clear chat window"),
+                "aliases": ["cl"],
+                "group": _("Chat")
+            },
+            "close": {
+                "callback": self.close_other_chat_command,
+                "description": _("Close private chat"),
+                "usage": ["<user>"],
+                "aliases": ["c"],
+                "group": _("Private Chat")
+            },
+            "ctcpversion": {
+                "callback": self.ctcpversion_other_chat_command,
+                "description": _("Ask for a user's client version"),
+                "usage": ["[user]"],
+                "group": _("Client-To-Client Protocol")
+            },
+            "leave": {
+                "callback": self.leave_chatroom_command,
+                "description": _("Leave chat room"),
+                "usage": ["[room]"],
+                "aliases": ["l"],
+                "group": _("Chat Rooms")
+            },
+        }
+
+        private_chat_commands = {
+            "help": {
+                "callback": self.help_private_chat_command,
+                "description": "Show commands",
+                "usage": ["[query]"],
+                "aliases": ["?"]
+            },
+            "clear": {
+                "callback": self.help_private_chat_command,
+                "description": _("Clear chat window"),
+                "aliases": ["cl"],
+                "group": _("Chat")
+            },
+            "close": {
+                "callback": self.close_private_chat_command,
+                "description": _("Close private chat"),
+                "usage": ["[user]"],
+                "aliases": ["c"],
+                "group": _("Private Chat")
+            },
+            "ctcpversion": {
+                "callback": self.ctcpversion_private_chat_command,
+                "description": _("Ask for a user's client version"),
+                "usage": ["[user]"],
+                "group": _("Client-To-Client Protocol")
+            },
+            "leave": {
+                "callback": self.leave_other_chat_command,
+                "description": _("Leave chat room"),
+                "usage": ["<room>"],
+                "aliases": ["l"],
+                "group": _("Chat Rooms")
+            },
+        }
+
         cli_commands = {
+            "help": {
+                "callback": self.help_cli_command,
+                "description": "Show commands",
+                "usage": ["[query]"],
+                "aliases": ["?"]
+            },
             "addshare": {
                 "callback": self.add_share_command,
                 "description": _("Add share"),
@@ -155,17 +179,23 @@ class Plugin(BasePlugin):
                 "callback": self.list_shares_command,
                 "description": _("List shares"),
                 "group": _("Shares")
+            },
+            "quit": {
+                "callback": self.quit_command,
+                "description": _("Quit Nicotine+"),
+                "usage": ["[force]"],
+                "aliases": ["q", "exit"]
             }
         }
 
-        self.chatroom_commands = {**commands, **chat_commands}
-        self.private_chat_commands = {**commands, **chat_commands}
+        self.chatroom_commands = {**commands, **chat_commands, **chatroom_commands}
+        self.private_chat_commands = {**commands, **chat_commands, **private_chat_commands}
         self.cli_commands = {**commands, **cli_commands}
 
-    def help_chatroom_command(self, args, _room):
+    def help_chatroom_command(self, args=None, _user=None, _room=None):
         self._list_commands(args, self.parent.chatroom_commands)
 
-    def help_private_chat_command(self, args, _user):
+    def help_private_chat_command(self, args=None, _user=None, _room=None):
         self._list_commands(args, self.parent.private_chat_commands)
 
     def help_cli_command(self, args):
@@ -219,7 +249,7 @@ class Plugin(BasePlugin):
     def _echo_unexpect_arg(self, arg):
         self.echo_message("Unexpected argument: %s" % arg.split(" ", maxsplit=1)[0])
 
-    def clear_chatroom_command(self, args, room):
+    def clear_chatroom_command(self, args=None, _user=None, _room=None):
 
         if args:
             self._echo_unexpect_arg(args)
@@ -227,7 +257,7 @@ class Plugin(BasePlugin):
 
         self.core.chatrooms.clear_messages(room)
 
-    def clear_private_chat_command(self, args, user):
+    def clear_private_chat_command(self, args=None, user=None, _room=None):
 
         if args:
             self._echo_unexpect_arg(args)
@@ -235,10 +265,10 @@ class Plugin(BasePlugin):
 
         self.core.privatechats.clear_messages(user)
 
-    def close_other_chat_command(self, args, _room):
-        self.close_private_chat_command(None, user=args)
+    def close_other_chat_command(self, args=None, _user=None, _room=None):
+        self.close_private_chat_command(args=args)
 
-    def close_private_chat_command(self, args, user=None):
+    def close_private_chat_command(self, args=None, user=None, _room=None):
 
         if args:
             user = args
@@ -247,18 +277,16 @@ class Plugin(BasePlugin):
             self.echo_message("Closing private chat of user %s" % user)
         elif user:
             self.echo_message("Not messaging with user %s" % user)
-        else:
-            self._echo_missing_arg('[user]')
 
         self.core.privatechats.remove_user(user)
 
-    def ctcpversion_other_chat_command(self, args, _room):
+    def ctcpversion_other_chat_command(self, args=None, _user=None, _room=None):
 
         user = args if args else self.core.login_username
 
-        self.ctcpversion_private_chat_command(None, user)
+        self.ctcpversion_private_chat_command(args=user)
 
-    def ctcpversion_private_chat_command(self, args, user=None):
+    def ctcpversion_private_chat_command(self, args=None, user=None, _room=None):
 
         if args:
             user = args
@@ -266,20 +294,16 @@ class Plugin(BasePlugin):
         if self.send_private(user, self.core.privatechats.CTCP_VERSION, show_ui=False):
             self.echo_message("Asked %s for client version" % user)
 
-    def hello_command(self, args):
+    def hello_command(self, args=None, _user=None, _room=None):
         self.echo_message("Hello there! %s" % args)
 
-    def join_chat_command(self, args):
+    def join_chat_command(self, args, _user, _room):
         self.core.chatrooms.show_room(args)
 
-    def leave_chatroom_command(self, args, room=None):
+    def leave_chatroom_command(self, args=None, _user=None, room=None):
 
         if args:
             room = args
-
-        if not room:
-            self._echo_missing_arg('[room]')
-            return
 
         if room not in self.core.chatrooms.joined_rooms:
             self.echo_message("Not joined in room %s" % room)
@@ -287,16 +311,16 @@ class Plugin(BasePlugin):
 
         self.core.chatrooms.remove_room(room)
 
-    def leave_other_chat_command(self, args, _user=None):
-        self.leave_chatroom_command(None, room=args)
+    def leave_other_chat_command(self, args=None, _user=None, _room=None):
+        self.leave_chatroom_command(args=args)
 
-    def me_chat_command(self, args):
+    def me_chat_command(self, args=None, _user=None, _room=None):
         self.send_message("/me " + args)
 
-    def msg_chat_command(self, args):
-        self.pm_chat_command(args, switch_page=False)
+    def msg_chat_command(self, args=None, _user=None, _room=None):
+        self.pm_chat_command(args=args, switch_page=False)
 
-    def pm_chat_command(self, args, switch_page=True):
+    def pm_chat_command(self, args=None, _user=None, _room=None, switch_page=True):
 
         args_split = args.split(" ", maxsplit=1)
         user, text = args_split[0], args_split[1] if len(args_split) == 2 else None
@@ -307,7 +331,7 @@ class Plugin(BasePlugin):
         if switch_page:
             self.log("Private chat with user %s" % user)
 
-    def say_chat_command(self, args):
+    def say_chat_command(self, args=None, _user=None, _room=None):
 
         args_split = args.split(" ", maxsplit=1)
         room, text = args_split[0], args_split[1]
@@ -315,35 +339,32 @@ class Plugin(BasePlugin):
         if self.send_public(room, text):
             self.log("Chat message sent to room %s" % room)
 
-    def add_share_command(self, _args):
+    def add_share_command(self, _args=None, _user=None, _room=None):
 
         # share_type, virtual_name, path = args.split(maxsplit=3)
 
         self.core.shares.rescan_shares()
 
-    def remove_share_command(self, _args):
+    def remove_share_command(self, _args=None, _user=None, _room=None):
 
         # share_type, virtual_name, *_unused = args.split(maxsplit=2)
 
         self.core.shares.rescan_shares()
 
-    def list_shares_command(self, _args):
+    def list_shares_command(self, _args=None, _user=None, _room=None):
         self.echo_message("nothing here yet")
 
-    def rescan_command(self, _args):
+    def rescan_command(self, _args=None, _user=None, _room=None):
         self.core.shares.rescan_shares()
 
-    def away_command(self, _args):
+    def away_command(self, _args=None, _user=None, _room=None):
         self.core.set_away_mode(self.core.user_status != 1, save_state=True)  # 1 = UserStatus.AWAY
         self.echo_message("Status is now %s" % (_("Online") if self.core.user_status == 2 else _("Away")))
 
-    def quit_program_chatroom_command(self, args, _room):
-        self.quit_command(args, interface="chatroom")
+    def quit_program_chat_command(self, args=None, _user=None, room=None):
+        self.quit_command(args=args, interface="chatroom" if room else "private_chat")
 
-    def quit_program_private_chat_command(self, args, _user):
-        self.quit_command(args, interface="private_chat")
-
-    def quit_program_command(self, args, interface="cli"):
+    def quit_command(self, args=None, interface="cli"):
 
         if args and args != "force":
             self._echo_unexpect_arg(args)

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -82,6 +82,7 @@ class Plugin(BasePlugin):
                 "callback": self.quit_program_chat_command,
                 "description": _("Quit Nicotine+"),
                 "usage": ["[force]"],
+                "choices": ["force"],
                 "aliases": ["q", "exit"]
             }
         }
@@ -97,6 +98,7 @@ class Plugin(BasePlugin):
                 "callback": self.clear_chatroom_command,
                 "description": _("Clear chat window"),
                 "aliases": ["cl"],
+                "choices": [-1],
                 "group": _("Chat")
             },
             "close": {
@@ -132,6 +134,7 @@ class Plugin(BasePlugin):
                 "callback": self.clear_private_chat_command,
                 "description": _("Clear chat window"),
                 "aliases": ["cl"],
+                "choices": [-1],
                 "group": _("Chat")
             },
             "close": {
@@ -184,6 +187,7 @@ class Plugin(BasePlugin):
                 "callback": self.quit_command,
                 "description": _("Quit Nicotine+"),
                 "usage": ["[force]"],
+                "choices": ["force"],
                 "aliases": ["q", "exit"]
             }
         }
@@ -192,13 +196,13 @@ class Plugin(BasePlugin):
         self.private_chat_commands = {**commands, **chat_commands, **private_chat_commands}
         self.cli_commands = {**commands, **cli_commands}
 
-    def help_chatroom_command(self, args=None, _user=None, _room=None):
+    def help_chatroom_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self._list_commands(args, self.parent.chatroom_commands)
 
-    def help_private_chat_command(self, args=None, _user=None, _room=None):
+    def help_private_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self._list_commands(args, self.parent.private_chat_commands)
 
-    def help_cli_command(self, args):
+    def help_cli_command(self, args=None):  # pylint: disable=unused-argument
         self._list_commands(args, self.parent.cli_commands)
 
     def _list_commands(self, args, command_list):
@@ -243,32 +247,16 @@ class Plugin(BasePlugin):
             for command in commands:
                 self.echo_message(command)
 
-    def _echo_missing_arg(self, arg):
-        self.echo_message("Missing argument: %s" % arg)
-
-    def _echo_unexpect_arg(self, arg):
-        self.echo_message("Unexpected argument: %s" % arg.split(" ", maxsplit=1)[0])
-
-    def clear_chatroom_command(self, args=None, _user=None, room=None):
-
-        if args:
-            self._echo_unexpect_arg(args)
-            return
-
+    def clear_chatroom_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.core.chatrooms.clear_messages(room)
 
-    def clear_private_chat_command(self, args=None, user=None, _room=None):
-
-        if args:
-            self._echo_unexpect_arg(args)
-            return
-
+    def clear_private_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.core.privatechats.clear_messages(user)
 
-    def close_other_chat_command(self, args=None, _user=None, _room=None):
+    def close_other_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.close_private_chat_command(args=args)
 
-    def close_private_chat_command(self, args=None, user=None, _room=None):
+    def close_private_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
 
         if args:
             user = args
@@ -280,13 +268,13 @@ class Plugin(BasePlugin):
 
         self.core.privatechats.remove_user(user)
 
-    def ctcpversion_other_chat_command(self, args=None, _user=None, _room=None):
+    def ctcpversion_other_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
 
         user = args if args else self.core.login_username
 
         self.ctcpversion_private_chat_command(args=user)
 
-    def ctcpversion_private_chat_command(self, args=None, user=None, _room=None):
+    def ctcpversion_private_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
 
         if args:
             user = args
@@ -294,13 +282,13 @@ class Plugin(BasePlugin):
         if self.send_private(user, self.core.privatechats.CTCP_VERSION, show_ui=False):
             self.echo_message("Asked %s for client version" % user)
 
-    def hello_command(self, args=None, _user=None, _room=None):
+    def hello_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.echo_message("Hello there! %s" % args)
 
-    def join_chat_command(self, args=None, _user=None, _room=None):
+    def join_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.core.chatrooms.show_room(args)
 
-    def leave_chatroom_command(self, args=None, _user=None, room=None):
+    def leave_chatroom_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
 
         if args:
             room = args
@@ -311,13 +299,13 @@ class Plugin(BasePlugin):
 
         self.core.chatrooms.remove_room(room)
 
-    def leave_other_chat_command(self, args=None, _user=None, _room=None):
+    def leave_other_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.leave_chatroom_command(args=args)
 
-    def me_chat_command(self, args=None, _user=None, _room=None):
+    def me_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.send_message("/me " + args)
 
-    def msg_chat_command(self, args=None, _user=None, _room=None):
+    def msg_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
 
         args_split = args.split(" ", maxsplit=1)
         user, text = args_split[0], args_split[1]
@@ -325,11 +313,11 @@ class Plugin(BasePlugin):
         if self.send_private(user, text, show_ui=True, switch_page=False):
             self.echo_message("Private message sent to user %s" % user)
 
-    def pm_chat_command(self, args=None, _user=None, _room=None):
+    def pm_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.core.privatechats.show_user(args)
-        self.log("Private chat with user %s" % user)
+        self.log("Private chat with user %s" % args)
 
-    def say_chat_command(self, args=None, _user=None, _room=None):
+    def say_chat_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
 
         args_split = args.split(" ", maxsplit=1)
         room, text = args_split[0], args_split[1]
@@ -337,36 +325,32 @@ class Plugin(BasePlugin):
         if self.send_public(room, text):
             self.log("Chat message sent to room %s" % room)
 
-    def add_share_command(self, _args=None, _user=None, _room=None):
+    def add_share_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
 
         # share_type, virtual_name, path = args.split(maxsplit=3)
 
         self.core.shares.rescan_shares()
 
-    def remove_share_command(self, _args=None, _user=None, _room=None):
+    def remove_share_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
 
         # share_type, virtual_name, *_unused = args.split(maxsplit=2)
 
         self.core.shares.rescan_shares()
 
-    def list_shares_command(self, _args=None, _user=None, _room=None):
+    def list_shares_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.echo_message("nothing here yet")
 
-    def rescan_command(self, _args=None, _user=None, _room=None):
+    def rescan_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.core.shares.rescan_shares()
 
-    def away_command(self, _args=None, _user=None, _room=None):
+    def away_command(self, args=None, user=None, room=None):  # pylint: disable=unused-argument
         self.core.set_away_mode(self.core.user_status != 1, save_state=True)  # 1 = UserStatus.AWAY
         self.echo_message("Status is now %s" % (_("Online") if self.core.user_status == 2 else _("Away")))
 
-    def quit_program_chat_command(self, args=None, _user=None, room=None):
+    def quit_program_chat_command(self, args=None, user=None, room=None):
         self.quit_command(args=args, interface="chatroom" if room else "private_chat")
 
     def quit_command(self, args=None, interface="cli"):
-
-        if args and args != "force":
-            self._echo_unexpect_arg(args)
-            return
 
         if "force" not in args:
             self.log("Exiting application on %s command %s" % (interface, args))

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -69,7 +69,7 @@ class Plugin(BasePlugin):
             "pm": {
                 "callback": self.pm_chat_command,
                 "description": _("Open private chat window for user"),
-                "usage": ["<user>", "[message..]"],
+                "usage": ["<user>"],
                 "group": _("Private Chat")
             },
             "say": {
@@ -318,18 +318,16 @@ class Plugin(BasePlugin):
         self.send_message("/me " + args)
 
     def msg_chat_command(self, args=None, _user=None, _room=None):
-        self.pm_chat_command(args=args, switch_page=False)
-
-    def pm_chat_command(self, args=None, _user=None, _room=None, switch_page=True):
 
         args_split = args.split(" ", maxsplit=1)
-        user, text = args_split[0], args_split[1] if len(args_split) == 2 else None
+        user, text = args_split[0], args_split[1]
 
-        if self.send_private(user, text, show_ui=True, switch_page=switch_page):
+        if self.send_private(user, text, show_ui=True, switch_page=False):
             self.echo_message("Private message sent to user %s" % user)
 
-        if switch_page:
-            self.log("Private chat with user %s" % user)
+    def pm_chat_command(self, args=None, _user=None, _room=None):
+        self.core.privatechats.show_user(args)
+        self.log("Private chat with user %s" % user)
 
     def say_chat_command(self, args=None, _user=None, _room=None):
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -228,14 +228,11 @@ class Plugin(BasePlugin):
 
         room = args if args else (source if command_type == "chatroom" else None)
 
-        if room in self.core.chatrooms.joined_rooms:
-            self.echo_message("Leaving room %s" % room)
-        elif room:
-            self.echo_message("Not joined in room %s" % room)
-        else:
+        if not room:
             return self._echo_missing_arg('[room]')
 
-        self.core.chatrooms.remove_room(room)
+        if not self.core.chatrooms.remove_room(room):
+            self.echo_message("Not joined in room %s" % room)
 
     def me_command(self, args, _command_type, _source):
         self.send_message("/me " + args)

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -93,7 +93,7 @@ class Plugin(BasePlugin):
             "msg": {
                 "callback": self.msg_command,
                 "description": _("Send private message to user"),
-                "usage": ["<user>", "[message..]"],
+                "usage": ["<user>", "<message..>"],
                 "aliases": ["m"],
                 "group": _("Private Chat")
             },

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -192,11 +192,12 @@ class Plugin(BasePlugin):
 
         if user in self.core.privatechats.users:
             self.echo_message("Closing private chat of user %s" % user)
-            self.core.privatechats.remove_user(user)
         elif user:
             self.echo_message("Not messaging with user %s" % user)
         else:
             self._echo_missing_arg('[user]')
+
+        self.core.privatechats.remove_user(user)
 
     def clear_command(self, args, command_type, source):
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -129,7 +129,7 @@ class Plugin(BasePlugin):
                 "aliases": ["?"]
             },
             "clear": {
-                "callback": self.help_private_chat_command,
+                "callback": self.clear_private_chat_command,
                 "description": _("Clear chat window"),
                 "aliases": ["cl"],
                 "group": _("Chat")
@@ -249,7 +249,7 @@ class Plugin(BasePlugin):
     def _echo_unexpect_arg(self, arg):
         self.echo_message("Unexpected argument: %s" % arg.split(" ", maxsplit=1)[0])
 
-    def clear_chatroom_command(self, args=None, _user=None, _room=None):
+    def clear_chatroom_command(self, args=None, _user=None, room=None):
 
         if args:
             self._echo_unexpect_arg(args)
@@ -297,7 +297,7 @@ class Plugin(BasePlugin):
     def hello_command(self, args=None, _user=None, _room=None):
         self.echo_message("Hello there! %s" % args)
 
-    def join_chat_command(self, args, _user, _room):
+    def join_chat_command(self, args=None, _user=None, _room=None):
         self.core.chatrooms.show_room(args)
 
     def leave_chatroom_command(self, args=None, _user=None, room=None):

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -109,6 +109,12 @@ class Plugin(BasePlugin):
                 "usage": ["<room>", "<message..>"],
                 "group": _("Chat Rooms")
             },
+            "ctcpversion": {
+                "callback": self.ctcpversion_command,
+                "description": _("Ask for a user's client version"),
+                "usage": ["[user]"],
+                "group": _("Client-To-Client Protocol")
+            }
         }
 
         cli_commands = {
@@ -279,8 +285,12 @@ class Plugin(BasePlugin):
         self.core.set_away_mode(self.core.user_status != 1, save_state=True)  # 1 = UserStatus.AWAY
         self.echo_message("Status is now %s" % (_("Online") if self.core.user_status == 2 else _("Away")))
 
-    def shutdown_notification(self):
-        self.log("Shutdown!")
+    def ctcpversion_command(self, args, command_type, source):
+
+        user = args if args else (source if command_type == "private_chat" else self.core.login_username)
+
+        if self.send_private(user, self.core.privatechats.CTCP_VERSION, show_ui=False):
+            self.echo_message("Asked %s for client version" % user)
 
     def quit_command(self, args, command_type, _source):
 
@@ -291,3 +301,6 @@ class Plugin(BasePlugin):
 
         self.log("Quitting on %s command %s" % (command_type, args))
         self.core.quit()
+
+    def shutdown_notification(self):
+        self.log("Shutdown!")

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -306,13 +306,10 @@ class Plugin(BasePlugin):
 
     def quit_command(self, args, command_type, _source):
 
-        if self.core.ui_callback and "force" not in args:  # and not command_type == "cli":
+        if "force" not in args:
             self.log("Exiting application on %s command %s" % (command_type, args))
-            # TODO: X Window System error 'BadImplementation (server does not implement operation)'
-            # '     Details: serial 28078 error_code 17 request_code 20 (core protocol) minor_code 0
-            self.core.ui_callback.on_quit()
+            self.core.confirm_quit()
             return
 
         self.log("Quitting on %s command %s" % (command_type, args))
-        # TODO: Gtk-ERROR **: 12:13:37.433: Unknown segment type: \x80\x9d\x9b\u0003
-        self.core.quit()  # Fatal Python error: Segmentation fault
+        self.core.quit()

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -145,12 +145,14 @@ class Plugin(BasePlugin):
                 "callback": self.add_share_command,
                 "description": _("Add share"),
                 "usage": ["<public|private>", "<virtual_name>", "<path>"],
+                "choices": ["public", "private"],
                 "group": _("Shares")
             },
             "removeshare": {
                 "callback": self.remove_share_command,
                 "description": _("Remove share"),
                 "usage": ["<public|private>", "<virtual_name>"],
+                "choices": ["public", "private"],
                 "group": _("Shares")
             },
             "listshares": {
@@ -214,7 +216,7 @@ class Plugin(BasePlugin):
             for command in commands:
                 self.echo_message(command)
 
-    def clear_command(self, args, user=None, room=None):
+    def clear_command(self, _args, user=None, room=None):
 
         if room is not None:
             self.core.chatrooms.clear_messages(room)
@@ -287,20 +289,22 @@ class Plugin(BasePlugin):
 
     def add_share_command(self, args):
 
-        # share_type, virtual_name, path = args.split(maxsplit=3)
+        args_split = args.split(" ", maxsplit=3)  # "\""
+        type, name, path = args_split[0], args_split[1], args_split[2]
 
-        self.core.shares.rescan_shares()
+        self.echo_message(f"nothing here yet, you entered: type='{type}' name='{name}' path='{path}'")
 
     def remove_share_command(self, args):
 
-        # share_type, virtual_name, *_unused = args.split(maxsplit=2)
+        args_split = args.split(" ", maxsplit=2)
+        type, name = args_split[0], args_split[1]
 
-        self.core.shares.rescan_shares()
+        self.echo_message(f"nothing here yet, you entered: type='{type}' name='{name}'")
 
     def list_shares_command(self, args):
-        self.echo_message("nothing here yet")
+        self.echo_message(f"nothing here yet, you entered: {args}")
 
-    def rescan_command(self, args, **_unused):
+    def rescan_command(self, _args, **_unused):
         self.core.shares.rescan_shares()
 
     def away_command(self, args, **_unused):

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -171,8 +171,9 @@ class Plugin(BasePlugin):
 
             description = data.get("description", "No description")
             group = data.get("group", _("Commands"))
+            group_words = group.lower().split(" ")
 
-            if not args or query in command or query in (a for a in aliases) or query.find(group.lower()) > -1:
+            if not args or query in command or query in (a for a in aliases) or query in group_words:
                 if group not in command_groups:
                     command_groups[group] = []
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -290,16 +290,16 @@ class Plugin(BasePlugin):
     def add_share_command(self, args):
 
         args_split = args.split(" ", maxsplit=3)  # "\""
-        type, name, path = args_split[0], args_split[1], args_split[2]
+        access, name, path = args_split[0], args_split[1], args_split[2]
 
-        self.echo_message(f"nothing here yet, you entered: type='{type}' name='{name}' path='{path}'")
+        self.echo_message(f"nothing here yet, you entered: access='{access}' name='{name}' path='{path}'")
 
     def remove_share_command(self, args):
 
         args_split = args.split(" ", maxsplit=2)
-        type, name = args_split[0], args_split[1]
+        access, name = args_split[0], args_split[1]
 
-        self.echo_message(f"nothing here yet, you entered: type='{type}' name='{name}'")
+        self.echo_message(f"nothing here yet, you entered: access='{access}' name='{name}'")
 
     def list_shares_command(self, args):
         self.echo_message(f"nothing here yet, you entered: {args}")
@@ -307,7 +307,7 @@ class Plugin(BasePlugin):
     def rescan_command(self, _args, **_unused):
         self.core.shares.rescan_shares()
 
-    def away_command(self, args, **_unused):
+    def away_command(self, _args, **_unused):
         self.core.set_away_mode(self.core.user_status != 1, save_state=True)  # 1 = UserStatus.AWAY
         self.echo_message("Status is now %s" % (_("Online") if self.core.user_status == 2 else _("Away")))
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -27,7 +27,11 @@ class Plugin(BasePlugin):
 
         commands = {
             "help": {
-                "callback": self.help_command,
+                "callbacks": {
+                    "chatroom": self.chatroom_help_command,
+                    "private_chat": self.private_chat_help_command,
+                    "cli": self.cli_help_command
+                },
                 "description": "Show commands",
                 "usage": ["[query]"],
                 "aliases": ["?"]
@@ -50,7 +54,11 @@ class Plugin(BasePlugin):
                 "aliases": ["a"]
             },
             "quit": {
-                "callback": self.quit_command,
+                "callbacks": {
+                    "chatroom": self.chatroom_quit_command,
+                    "private_chat": self.private_chat_quit_command,
+                    "cli": self.quit_command
+                },
                 "description": _("Quit Nicotine+"),
                 "usage": ["[force]"],
                 "aliases": ["q", "exit"]
@@ -59,13 +67,20 @@ class Plugin(BasePlugin):
 
         chat_commands = {
             "clear": {
-                "callback": self.clear_command,
+                "callbacks": {
+                    "chatroom": self.chatroom_clear_command,
+                    "private_chat": self.private_chat_clear_command,
+                    "cli": self.cli_clear_command
+                },
                 "description": _("Clear chat window"),
                 "aliases": ["cl"],
                 "group": _("Chat")
             },
             "close": {
-                "callback": self.close_command,
+                "callbacks": {
+                    "chatroom": self.chatroom_close_command,
+                    "private_chat": self.private_chat_close_command,
+                },
                 "description": _("Close private chat"),
                 "usage": ["[user]"],
                 "aliases": ["c"],
@@ -79,7 +94,10 @@ class Plugin(BasePlugin):
                 "group": _("Chat Rooms")
             },
             "leave": {
-                "callback": self.leave_command,
+                "callbacks": {
+                    "chatroom": self.chatroom_leave_command,
+                    "private_chat": self.private_chat_leave_command,
+                },
                 "description": _("Leave chat room"),
                 "usage": ["[room]"],
                 "aliases": ["l"],
@@ -111,7 +129,11 @@ class Plugin(BasePlugin):
                 "group": _("Chat Rooms")
             },
             "ctcpversion": {
-                "callback": self.ctcpversion_command,
+                "callbacks": {
+                    "chatroom": self.chatroom_ctcpversion_command,
+                    "private_chat": self.private_chat_ctcpversion_command,
+                    "cli": self.cli_ctcpversion_command
+                },
                 "description": _("Ask for a user's client version"),
                 "usage": ["[user]"],
                 "group": _("Client-To-Client Protocol")
@@ -142,18 +164,18 @@ class Plugin(BasePlugin):
         self.private_chat_commands = {**commands, **chat_commands}
         self.cli_commands = {**commands, **cli_commands}
 
-    def help_command(self, args, user=None, room=None):
+    def chatroom_help_command(self, args, _room):
+        self._help_command(args, self.parent.chatroom_commands)
+
+    def private_chat_help_command(self, args, _user):
+        self._help_command(args, self.parent.private_chat_commands)
+
+    def cli_help_command(self, args):
+        self._help_command(args, self.parent.cli_commands)
+
+    def _help_command(self, args, command_list):
 
         query = args.split(" ", maxsplit=1)[0].lower().lstrip("/")
-
-        if room is not None:
-            command_list = self.parent.chatroom_commands
-
-        elif user is not None:
-            command_list = self.parent.private_chat_commands
-
-        else:
-            command_list = self.parent.cli_commands
 
         command_groups = {}
         num_commands = 0
@@ -199,7 +221,10 @@ class Plugin(BasePlugin):
     def _echo_unexpect_arg(self, arg):
         self.echo_message("Unexpected argument: %s" % arg.split(" ", maxsplit=1)[0])
 
-    def close_command(self, args, user=None, _room=None):
+    def chatroom_close_command(self, args, _room):
+        self.private_chat_close_command(args)
+
+    def private_chat_close_command(self, args, user=None):
 
         if args:
             user = args
@@ -213,23 +238,29 @@ class Plugin(BasePlugin):
 
         self.core.privatechats.remove_user(user)
 
-    def clear_command(self, args, user=None, room=None):
+    def chatroom_clear_command(self, args, room):
 
         if args:
             self._echo_unexpect_arg(args)
             return
 
-        if room is not None:
-            self.core.chatrooms.clear_messages(room)
+        self.core.chatrooms.clear_messages(room)
+
+    def private_chat_clear_command(self, args, user):
+
+        if args:
+            self._echo_unexpect_arg(args)
             return
 
-        if user is not None:
-            self.core.privatechats.clear_messages(user)
+        self.core.privatechats.clear_messages(user)
 
-    def join_command(self, args, _user=None, _room=None):
+    def cli_clear_command(self, args):
+        self.echo_message("you really shouldn't see this")
+
+    def join_command(self, args):
         self.core.chatrooms.show_room(args)
 
-    def leave_command(self, args, _user=None, room=None):
+    def chatroom_leave_command(self, args, room=None):
 
         if args:
             room = args
@@ -240,34 +271,34 @@ class Plugin(BasePlugin):
 
         if room not in self.core.chatrooms.joined_rooms:
             self.echo_message("Not joined in room %s" % room)
-            return
+            # return  # in future the gui might need to close a tab even if we are not joined, such as while offline etc
 
         self.core.chatrooms.remove_room(room)
 
-    def me_command(self, args, _user=None, _room=None):
+    def private_chat_leave_command(self, args, _user):
+        self.chatroom_leave_command(args)
+
+    def me_command(self, args):
         self.send_message("/me " + args)
 
-    def msg_command(self, args, user=None, room=None):
-        self.private_message_command(args, user=user, room=room, switch_page=False)
+    def msg_command(self, args):
+        self.private_message_command(args, switch_page=False)
 
-    def private_message_command(self, args, user=None, _room=None, switch_page=True):
+    def private_message_command(self, args, switch_page=True):
 
         args_split = args.split(" ", maxsplit=1)
         user, text = args_split[0], args_split[1] if len(args_split) == 2 else None
 
-        if not self.send_private(user, text, show_ui=True, switch_page=switch_page):
-            return
+        if self.send_private(user, text, show_ui=True, switch_page=switch_page):
+            self.echo_message("Private message sent to user %s" % user)
 
         if switch_page:
             self.log("Private chat with user %s" % user)
-            return
 
-        self.log("Private message sent to user %s" % user)
-
-    def rescan_command(self, _args, _user=None, _room=None):
+    def rescan_command(self, _args):
         self.core.shares.rescan_shares()
 
-    def say_command(self, args, _user=None, room=None):
+    def say_command(self, args):
 
         args_split = args.split(" ", maxsplit=1)
         room, text = args_split[0], args_split[1]
@@ -275,29 +306,35 @@ class Plugin(BasePlugin):
         if self.send_public(room, text):
             self.log("Chat message sent to room %s" % room)
 
-    def hello_command(self, args, _user=None, _room=None):
+    def hello_command(self, args):
         self.echo_message("Hello there! %s" % args)
 
-    def add_share_command(self, _args, _user=None, _room=None):
+    def add_share_command(self, _args):
 
         # share_type, virtual_name, path = args.split(maxsplit=3)
 
         self.core.shares.rescan_shares()
 
-    def remove_share_command(self, _args, _user=None, _room=None):
+    def remove_share_command(self, _args):
 
         # share_type, virtual_name, *_unused = args.split(maxsplit=2)
 
         self.core.shares.rescan_shares()
 
-    def list_shares_command(self, _args, _user=None, _room=None):
+    def list_shares_command(self, _args):
         self.echo_message("nothing here yet")
 
-    def away_command(self, _args, _user=None, _room=None):
+    def away_command(self, _args):
         self.core.set_away_mode(self.core.user_status != 1, save_state=True)  # 1 = UserStatus.AWAY
         self.echo_message("Status is now %s" % (_("Online") if self.core.user_status == 2 else _("Away")))
 
-    def ctcpversion_command(self, args, user=None, _room=None):
+    def chatroom_ctcpversion_command(self, args, _room):
+
+        user = args if args else self.core.login_username
+
+        self.private_chat_ctcpversion_command(user)
+
+    def private_chat_ctcpversion_command(self, args, user=None):
 
         if args:
             user = args
@@ -305,14 +342,29 @@ class Plugin(BasePlugin):
         if self.send_private(user, self.core.privatechats.CTCP_VERSION, show_ui=False):
             self.echo_message("Asked %s for client version" % user)
 
-    def quit_command(self, args, _user=None, _room=None):
+    def cli_ctcpversion_command(self, args):
+        self.private_chat_ctcpversion_command(args)
+        self.echo_message("... but you won't see that answer here, so here you go:")
+        self.echo_message("%s %s" % (self.config.application_name, self.config.version))
+
+    def chatroom_quit_command(self, args, _room):
+        self.quit_command(args, interface="chatroom")
+
+    def private_chat_quit_command(self, args, _user):
+        self.quit_command(args, interface="private_chat")
+
+    def quit_command(self, args, interface="cli"):
+
+        if args and args != "force":
+            self._echo_unexpect_arg(args)
+            return
 
         if "force" not in args:
-            self.log("Exiting application on %s command %s" % ("temp", args))
+            self.log("Exiting application on %s command %s" % (interface, args))
             self.core.confirm_quit()
             return
 
-        self.log("Quitting on %s command %s" % ("temp", args))
+        self.log("Quitting on %s command %s" % (interface, args))
         self.core.quit()
 
     def shutdown_notification(self):

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -98,7 +98,7 @@ class Plugin(BasePlugin):
                 "group": _("Private Chat")
             },
             "pm": {
-                "callback": self.pm_command,
+                "callback": self.private_message_command,
                 "description": _("Open private chat window for user"),
                 "usage": ["<user>", "[message..]"],
                 "group": _("Private Chat")
@@ -187,7 +187,6 @@ class Plugin(BasePlugin):
             self.echo_message("Not chatting with user %s" % args)
 
         elif command_type != "private_chat":
-            # TODO: maybe consider diverting to leave_command(room)
             self.echo_message("Missing argument: %s" % ('[user]'))
 
     def clear_command(self, args, command_type, source):
@@ -237,37 +236,15 @@ class Plugin(BasePlugin):
         self.send_message("/me " + args)
 
     def msg_command(self, args, _command_type, _source):
-        # Send private chat [message] to <user> or open chat window if no [message]
+        self.private_message_command(args, _command_type, _source, switch_page=False)
+
+    def private_message_command(self, args, _command_type, _source, switch_page=True):
 
         args_split = args.split(" ", maxsplit=1)
         user, text = args_split[0], args_split[1] if len(args_split) == 2 else None
 
-        if text:
-            self.send_private(user, text, switch_page=False)
+        if self.send_private(user, text, show_ui=True, switch_page=switch_page):
             self.echo_message("Private message sent to user %s" % user)
-        else:
-            self.core.privatechats.show_user(user)
-            self.echo_message("Private chat opened with user %s" % user)
-
-    def pm_command(self, args, _command_type, _source):
-        # Open private chat window for <user> and optionally send [message]
-
-        args_split = args.split(" ", maxsplit=1)
-        user, text = args_split[0], args_split[1] if len(args_split) == 2 else None
-
-        if text:
-            self.send_private(user, text, switch_page=True)
-            self.echo_message("Private message sent to user %s" % user)
-        else:
-            self.core.privatechats.show_user(user)
-            self.echo_message("Private chat opened with user %s" % user)
-
-    def private_message_command(self, _args, _command_type, _source):  # , switch_page=True):
-        # TODO: combine pm_command(switch_page=True) with msg_command(switch_page=False)
-        #
-        # "Plugin core_commands failed with error <class 'TypeError'>:
-        # private_message_command() got multiple values for argument 'switch_page'.
-        pass
 
     def rescan_command(self, _args, _command_type, _source):
         self.core.shares.rescan_shares()

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -228,7 +228,7 @@ class Plugin(BasePlugin):
         if room in self.core.chatrooms.joined_rooms:
             self.echo_message("Leaving room %s" % room)
         else:
-            self.echo_message("Not in room %s" % room)
+            self.echo_message("Not joined in room %s" % room)
 
         self.core.chatrooms.remove_room(room)
 
@@ -276,12 +276,8 @@ class Plugin(BasePlugin):
         args_split = args.split(" ", maxsplit=1)
         room, text = args_split[0], args_split[1]
 
-        if not room in self.core.chatrooms.joined_rooms:
-            self.echo_message("Not joined in room %s" % room)
-            return
-
-        self.send_public(room, text)
-        self.echo_message("Chat message sent to room %s" % room)
+        if self.send_public(room, text):
+            self.echo_message("Chat message sent to room %s" % room)
 
     def hello_command(self, args, _command_type, _source):
         self.echo_message("Hello there! %s" % args)
@@ -310,7 +306,7 @@ class Plugin(BasePlugin):
 
     def quit_command(self, args, command_type, _source):
 
-        if self.core.ui_callback and not "force" in args:  # and not command_type == "cli":
+        if self.core.ui_callback and "force" not in args:  # and not command_type == "cli":
             self.log("Exiting application on %s command %s" % (command_type, args))
             # TODO: X Window System error 'BadImplementation (server does not implement operation)'
             # '     Details: serial 28078 error_code 17 request_code 20 (core protocol) minor_code 0

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -45,7 +45,8 @@ class Plugin(BasePlugin):
             },
             "away": {
                 "callback": self.away_command,
-                "description": "Toggle away status"
+                "description": _("Toggle away status"),
+                "aliases": ["a"]
             },
             "quit": {
                 "callback": self.quit_command,
@@ -299,7 +300,7 @@ class Plugin(BasePlugin):
 
     def away_command(self, _args, _command_type, _source):
         self.core.set_away_mode(self.core.user_status != 1, save_state=True)  # 1 = UserStatus.AWAY
-        self.echo_message("Status is now %s" % ("Online" if self.core.user_status == 2 else "Away"))
+        self.echo_message("Status is now %s" % (_("Online") if self.core.user_status == 2 else _("Away")))
 
     def shutdown_notification(self):
         self.log("Shutdown!")

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -205,16 +205,14 @@ class Plugin(BasePlugin):
 
         room = args
 
-        if room in self.core.chatrooms.joined_rooms:
-            # TODO: core needs show_room() tab switch ui_callback
-            self.echo_message("Already joined in room %s" % room)
-            return
-
         if room not in self.core.chatrooms.server_rooms and room not in self.core.chatrooms.private_rooms:
             self.echo_message("Creating new room %s" % room)
+        elif room in self.core.chatrooms.joined_rooms:
+            self.echo_message("Chatting in room %s" % room)
+        else:
+            self.echo_message("Joining room %s" % room)
 
-        self.echo_message("Joining room %s" % room)
-        self.core.chatrooms.request_join_room(room)
+        self.core.chatrooms.show_room(room)
 
     def leave_command(self, args, command_type, source):
 
@@ -227,12 +225,12 @@ class Plugin(BasePlugin):
             self.echo_message("Missing argument: %s" % ('[room]'))
             return
 
-        if not room in self.core.chatrooms.joined_rooms:
-            self.echo_message("Not joined in room %s" % room)
-            return
+        if room in self.core.chatrooms.joined_rooms:
+            self.echo_message("Leaving room %s" % room)
+        else:
+            self.echo_message("Not in room %s" % room)
 
-        self.echo_message("Leaving room %s" % room)
-        self.core.chatrooms.request_leave_room(room)
+        self.core.chatrooms.remove_room(room)
 
     def me_command(self, args, _command_type, _source):
         self.send_message("/me " + args)

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -173,7 +173,16 @@ class BasePlugin:
         log.add(self.human_name + ": " + msg, msg_args)
 
     def send_public(self, room, text):
-        self.core.queue.append(slskmessages.SayChatroom(room, text))
+        """ Send a public message to the specified chat room """
+
+        if room not in self.core.chatrooms.joined_rooms:
+            self.echo_message("Not joined in room %s" % room)
+
+        elif text:
+            self.core.queue.append(slskmessages.SayChatroom(room, text))
+            return True
+
+        return False
 
     def send_private(self, user, text, show_ui=True, switch_page=True):
         """ Send user message in private.

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -743,16 +743,27 @@ class PluginHandler:
                             plugin.echo_message("Usage: %s %s" % ('/' + command, " ".join(usage)))
                             return
 
-                    if room is not None:
-                        getattr(plugin, data.get("callback").__name__)(args, room=room)
+                    callback = data.get("callback")
+                    callbacks = data.get("callbacks")
 
-                    elif user is not None:
-                        getattr(plugin, data.get("callback").__name__)(args, user=user)
+                    if callbacks:
+                        if room is not None:
+                            callback = callbacks.get("chatroom")
 
-                    else:
-                        getattr(plugin, data.get("callback").__name__)(args)
+                            return getattr(plugin, callback.__name__)(args, room)
 
-                    return
+                        elif user is not None:
+                            callback = callbacks.get("private_chat")
+
+                            return getattr(plugin, callback.__name__)(args, user)
+
+                        elif callbacks.get("cli"):
+                            callback = callbacks.get("cli")
+
+                    if not callback:
+                        return
+
+                    return getattr(plugin, callback.__name__)(args)
 
             except Exception:
                 self.show_plugin_error(module, sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2])

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -729,25 +729,26 @@ class PluginHandler:
                         continue
 
                     usage = data.get("usage")
-                    choices = data.get("choices")
-                    num_args = len(args.split())
-                    failure = None
+                    choices = data.get("choices", [])
+                    args_split = args.split(maxsplit=3)
+                    num_args = len(args_split)
+                    reject = None
 
-                    if choices and args and -1 in choices:  # or len(list(x for x in choices)) < num_args:
-                        failure = f"Unexpected argument [{args}]"
+                    if args and -1 in choices:
+                        reject = f"Unexpected argument >{args_split[0]}<"
 
-                    elif choices and args and " ".join(choices) not in args:
-                        failure = "Incorrect argument (possible choices: %s)" % " | ".join(choices)
+                    elif args and choices and args_split[0] not in choices:
+                        reject = "Invalid argument, possible choices: %s" % " | ".join(choices)
 
                     elif usage:
                         num_usage = len(list(x for x in usage if x.startswith("<")))
 
                         if num_args < num_usage:
-                            failure = "Missing argument"
+                            reject = "Missing argument"
 
-                    if failure:
-                        description = (data.get("description") or "execute command").lower()
-                        plugin.echo_message(f"Cannot {description}: {failure}")
+                    if reject:
+                        description = data.get("description", "execute command").lower()
+                        plugin.echo_message(f"Cannot {description}: {reject}")
                         plugin.echo_message("Usage: %s %s" % ('/' + command, " ".join(usage) if usage else ""))
                         return
 

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -244,6 +244,9 @@ class BasePlugin:
 
         function(source, text, message_type)
 
+    def echo_unknown_command(self, command):
+        self.echo_message(_("Unknown command: %s. Type /help for a list of commands.") % ("/" + command))
+
     # Obsolete functions
 
     def saypublic(self, _room, _text):
@@ -740,7 +743,7 @@ class PluginHandler:
                 return
 
         if plugin is not None:
-            plugin.echo_message(_("Unknown command %s. Type /help for a list of commands.") % ("/" + command))
+            self.echo_unknown_command(command)
 
         self.command_source = None
         return

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -743,7 +743,7 @@ class PluginHandler:
                 return
 
         if plugin is not None:
-            self.echo_unknown_command(command)
+            plugin.echo_unknown_command(command)
 
         self.command_source = None
         return

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -190,9 +190,9 @@ class BasePlugin:
         switch_page controls whether the user's private chat view should be opened. """
 
         if show_ui:
-            self.core.privatechats.show_user(user, switch_page)
+            self.core.privatechats.show_user(user, switch_page=switch_page)
 
-        self.core.privatechats.send_message(user, text)
+        return self.core.privatechats.send_message(user, text)
 
     def echo_public(self, room, text, message_type="local"):
         """ Display a raw message in chat rooms (not sent to others).

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -180,9 +180,6 @@ class BasePlugin:
 
         elif text:
             self.core.queue.append(slskmessages.SayChatroom(room, text))
-            return True
-
-        return False
 
     def send_private(self, user, text, show_ui=True, switch_page=True):
         """ Send user message in private.

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -743,27 +743,16 @@ class PluginHandler:
                             plugin.echo_message("Usage: %s %s" % ('/' + command, " ".join(usage)))
                             return
 
-                    callback = data.get("callback")
-                    callbacks = data.get("callbacks")
+                    if room is not None:
+                        getattr(plugin, data.get("callback").__name__)(args, None, room)
 
-                    if callbacks:
-                        if room is not None:
-                            callback = callbacks.get("chatroom")
+                    elif user is not None:
+                        getattr(plugin, data.get("callback").__name__)(args, user, None)
 
-                            return getattr(plugin, callback.__name__)(args, room)
+                    else:
+                        getattr(plugin, data.get("callback").__name__)(args)
 
-                        elif user is not None:
-                            callback = callbacks.get("private_chat")
-
-                            return getattr(plugin, callback.__name__)(args, user)
-
-                        elif callbacks.get("cli"):
-                            callback = callbacks.get("cli")
-
-                    if not callback:
-                        return
-
-                    return getattr(plugin, callback.__name__)(args)
+                    return
 
             except Exception:
                 self.show_plugin_error(module, sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2])

--- a/pynicotine/privatechat.py
+++ b/pynicotine/privatechat.py
@@ -159,22 +159,26 @@ class PrivateChats:
 
     def send_message(self, user, message):
 
-        user_text = self.core.pluginhandler.outgoing_private_chat_event(user, message)
-        if user_text is None:
-            return
+        user, message = self.core.pluginhandler.outgoing_private_chat_event(user, message)
 
-        user, message = user_text
+        if user is None or message is None:
+            return False
 
         if message == self.CTCP_VERSION:
             ui_message = "CTCP VERSION"
         else:
             message = ui_message = self.auto_replace(message)
 
+        if message == "":
+            return False
+
         self.queue.append(slskmessages.MessageUser(user, message))
         self.core.pluginhandler.outgoing_private_chat_notification(user, message)
 
         if self.ui_callback:
             self.ui_callback.send_message(user, ui_message)
+
+        return True
 
     def get_user_status(self, msg):
         """ Server code: 7 """

--- a/pynicotine/privatechat.py
+++ b/pynicotine/privatechat.py
@@ -80,7 +80,7 @@ class PrivateChats:
         if user in self.config.sections["privatechat"]["users"]:
             self.config.sections["privatechat"]["users"].remove(user)
 
-        self.users.remove(user)
+        self.users.discard(user)
 
         if self.ui_callback:
             self.ui_callback.remove_user(user)

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -124,7 +124,7 @@ class NicotineCore:
             if args:
                 (args,) = args
 
-            self.pluginhandler.trigger_cli_command_event(command, args or "")
+            self.network_callback([slskmessages.CLICommand(command, args)])
 
     """ Actions """
 
@@ -285,6 +285,7 @@ class NicotineCore:
             slskmessages.PrivateRoomRemoveOperator: self.chatrooms.private_room_remove_operator,
             slskmessages.PublicRoomMessage: self.chatrooms.public_room_message,
             slskmessages.ShowConnectionErrorMessage: self.show_connection_error_message,
+            slskmessages.CLICommand: self.cli_command,
             slskmessages.UnknownPeerMessage: self.dummy_message
         }
 
@@ -479,6 +480,9 @@ class NicotineCore:
     def dummy_message(msg):
         # Ignore received message
         pass
+
+    def cli_command(self, msg):
+        self.pluginhandler.trigger_cli_command_event(msg.command, msg.args or "")
 
     def show_connection_error_message(self, msg):
         """ Request UI to show error messages related to connectivity """

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -109,6 +109,13 @@ class InternalMessage:
     msgtype = MessageType.INTERNAL
 
 
+class CLICommand(InternalMessage):
+
+    def __init__(self, command=None, args=None):
+        self.command = command
+        self.args = args
+
+
 class CloseConnection(InternalMessage):
 
     def __init__(self, sock=None):


### PR DESCRIPTION
+ Changed: Adapt to recent core changes for calling `clear_message()`, `show_room()` and `remove_room()` methods
- Removed: No longer need to avoid joining already joined room as this scenario is now properly handled by the core
+ Added: Core check for joined room membership before attempting to leave room, but still allow offline tab closing
+ Added: Core check for joined room membership before sending any public chat message via plugin using `send_public()`
+ Changed: Core, when closing private chat, discard the user instead of remove, to avoid possible ValueError if not exist.

+ Added: `/ctcpversion` command
+ Added: Optional query argument for the `/help` command, enable finding specific commands, aliases or group names.

In theroey the commands should work from any interface, but they have only been tested in `chatrooms` and `private_chat`.

The different usages of the commands between public/private chats require some extra fiddling about with the optional/required `args` for the different `command_type`s. maybe built-in (user=None, room=None) might be more helpful than `source`, because then _trigger_command() could enforce the appropriate required arguments if the commands were duplicated with differing `usage`.

Ready for merging into your cli-commands-test branch @mathiascode , the "Users" and "Search" commands will be in separate PRs.