### PR TITLE
cli/application.py: implement confirm_quit() to fix a TypeError in headless

### DIFF
--- a/pynicotine/cli/application.py
+++ b/pynicotine/cli/application.py
@@ -141,10 +141,10 @@ class Application:
         # Not implemented
         pass
 
-    def confirm_quit(self):
-        # Not implemented
-        pass
+    def confirm_quit(self, _remember):
+        log.add(_('Quit Nicotine+'))
+        self.core.quit()
 
     def quit(self):
-        # Not implemented
+        # Not needed
         pass


### PR DESCRIPTION
Fixes a TypeError when running the /quit command without arguments from the headless mode cli.

```
/quit
[2022-10-19 23:07:19] core_commands: Exiting application on cli command 
[2022-10-19 23:07:19] Plugin core_commands failed with error <class 'TypeError'>: confirm_quit() takes 1 positional argument but 2 were given.
Trace:   File "/home/user/Git/slook/nicotine-plus/pynicotine/pluginsystem.py", line 762, in _trigger_command
    getattr(plugin, data.get("callback").__name__)(args)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/plugins/core_commands/__init__.py", line 327, in quit_command
    self.core.confirm_quit()
  File "/home/user/Git/slook/nicotine-plus/pynicotine/pynicotine.py", line 295, in confirm_quit
    self.ui_callback.confirm_quit(remember)
```

The bug probably also affects master but cannot test there because master does not have headless input.