### PR TITLE
core_commands: add core user commands (testing branch)

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -25,14 +25,14 @@ jobs:
 
       - name: Prepare artifacts
         run: |
-          mkdir ../build/
-          cp -Lr ../nicotine_* ../build/
+          mkdir build/package/
+          cp -Lr ../nicotine_* build/package/
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: debian-package
-          path: ../build/
+          path: build/package/
 
   flatpak:
     runs-on: ubuntu-20.04
@@ -40,7 +40,7 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-43
       options: --privileged
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
       with:
         bundle: flatpak-package.flatpak
@@ -65,7 +65,7 @@ jobs:
       NICOTINE_LIBADWAITA: 0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -87,13 +87,13 @@ jobs:
           python3 packaging/windows/setup.py bdist_msi
 
       - name: Archive installer artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-${{ matrix.arch }}-installer
           path: packaging/windows/build/*.msi
 
       - name: Archive package artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-${{ matrix.arch }}-package
           path: packaging/windows/build/package
@@ -105,7 +105,7 @@ jobs:
       NICOTINE_LIBADWAITA: 1
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -123,7 +123,7 @@ jobs:
           python3 packaging/macos/setup.py bdist_dmg
 
       - name: Archive installer artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macos-installer
           path: packaging/macos/build/*.dmg

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -84,7 +84,12 @@ jobs:
 
       - name: Freeze application
         run: |
-          python3 packaging/windows/setup.py bdist_msi
+          python3 packaging/windows/setup.py build_exe
+
+          # Workaround for https://github.com/nicotine-plus/nicotine-plus/issues/2218
+          cp packaging/windows/build/package/Nicotine+/lib/libgcc*.dll packaging/windows/build/package/Nicotine+/
+          cp packaging/windows/build/package/Nicotine+/lib/libwinpthread*.dll packaging/windows/build/package/Nicotine+/
+          python3 packaging/windows/setup.py bdist_msi --skip-build
 
       - name: Archive installer artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,12 @@ jobs:
       NICOTINE_GTK_VERSION: ${{ matrix.gtk }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -53,7 +53,7 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
       GSK_RENDERER: cairo
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -111,7 +111,7 @@ jobs:
       NICOTINE_GTK_VERSION: ${{ matrix.gtk }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: python -m pylint pynicotine test
 
       - name: Integration and unit tests
-        run: xvfb-run python -m unittest
+        run: xvfb-run python -m unittest -v
 
   ubuntu-dep8:
     runs-on: ${{ matrix.os }}
@@ -100,7 +100,7 @@ jobs:
         run: python3 -m pylint pynicotine test
 
       - name: Integration and unit tests
-        run: python3 -m unittest
+        run: python3 -m unittest -v
 
   macos:
     runs-on: macos-10.15
@@ -130,4 +130,4 @@ jobs:
         run: pylint pynicotine test
 
       - name: Integration and unit tests
-        run: python3 -m unittest
+        run: python3 -m unittest -v

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # This file is responsible for including all necessary files in the source distribution
-# https://docs.python.org/3/distutils/sourcedist.html
+# https://packaging.python.org/en/latest/guides/using-manifest-in/
 
 recursive-include data *.in
 recursive-include po *

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,43 @@
 # Release Notes
 
+## Version 3.2.6 (October 21, 2022)
+
+### Changes
+
+ * Added F6 shortcut to move keyboard focus to the headerbar/toolbar
+ * Added an option to clear all uploads with a "User logged off" status
+ * Removed AppIndicator dependency in favor of custom tray icon implementation
+
+### Corrections
+
+ * IMPORTANT: Fixed a regression where uploads to slskd users were stuck at "Transferring"
+ * IMPORTANT: Fixed an issue where private messages from offline users were ignored
+ * IMPORTANT: Fixed an issue where certain uploads were incorrectly marked as "Cancelled"
+ * IMPORTANT - OpenBSD: Fixed a regression where incoming peer connections did not work
+ * Fixed a crash when uploading large files on a 32-bit system
+ * Fixed an issue where redundant protocol messages could be sent to the server indefinitely
+ * Fixed an issue where UPnP did not work on MikroTik routers
+ * Fixed an issue where the progress bar would get stuck if a share browse request ended abruptly
+ * Windows: Fixed an issue where network drives could not be shared
+ * Flatpak: Fixed an issue where the GUI was not translated to the system language
+
+### Issues closed on GitHub
+
+ * Clear Finished also clears uploads/downloads with "User logged off" status ([#2081](https://github.com/nicotine-plus/nicotine-plus/issues/2081))
+ * Scanning taking many hours ([#2173](https://github.com/nicotine-plus/nicotine-plus/issues/2173))
+ * Users can't connect to me after upgrade to 3.2.5 (transfers don't work) on OpenBSD ([#2175](https://github.com/nicotine-plus/nicotine-plus/issues/2175))
+ * Some bugs in Nicotine+ v. 3.2.5 ([#2184](https://github.com/nicotine-plus/nicotine-plus/issues/2184))
+ * Search Files: Keyboard shortcut to focus search bar ([#2186](https://github.com/nicotine-plus/nicotine-plus/issues/2186))
+ * Offline messages not popping up in tabs ([#2189](https://github.com/nicotine-plus/nicotine-plus/issues/2189))
+ * Samba Share hosted by Linux, mounted on Windows Failing ([#2190](https://github.com/nicotine-plus/nicotine-plus/issues/2190))
+ * Can't exit Room tabs when internet connection is off ([#2192](https://github.com/nicotine-plus/nicotine-plus/issues/2192))
+ * The flatpak version of Nicotine+ is using the wrong language ([#2194](https://github.com/nicotine-plus/nicotine-plus/issues/2194))
+ * Uploads partly broken ([#2197](https://github.com/nicotine-plus/nicotine-plus/issues/2197))
+ * Error code 725: OnlyPermanentLeasesSupported ([#2200](https://github.com/nicotine-plus/nicotine-plus/issues/2200))
+ * Critical error ([#2215](https://github.com/nicotine-plus/nicotine-plus/issues/2215))
+ * OverflowError ([#2216](https://github.com/nicotine-plus/nicotine-plus/issues/2216))
+
+
 ## Version 3.2.5 (August 31, 2022)
 
 ### Corrections

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Check out the [screenshots](data/screenshots/SCREENSHOTS.md) and [source code](h
 
 ## Download
 
-The current stable version of Nicotine+ is 3.2.5, released on August 31, 2022. See the [release notes](NEWS.md).
+The current stable version of Nicotine+ is 3.2.6, released on October 21, 2022. See the [release notes](NEWS.md).
 
 Downloads are available for:
 

--- a/data/org.nicotine_plus.Nicotine.appdata.xml.in
+++ b/data/org.nicotine_plus.Nicotine.appdata.xml.in
@@ -57,6 +57,8 @@
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
   <releases>
+    <release version="3.2.6" date="2022-10-21"/>
+    <release version="3.2.5" date="2022-08-31"/>
     <release version="3.2.4" date="2022-08-07"/>
     <release version="3.2.3" date="2022-08-05"/>
     <release version="3.2.2" date="2022-03-19"/>

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,13 @@ nicotine (3.3.0-dev3) jammy; urgency=medium
 
   * Development version.
 
- -- Mat <mail@mathias.is>  Wed, 31 Aug 2022 06:08:34 +0300
+ -- Mat <mail@mathias.is>  Fri, 21 Oct 2022 16:17:39 +0300
+
+nicotine (3.2.6-1) jammy; urgency=medium
+
+  * Latest upstream.
+
+ -- Mat <mail@mathias.is>  Fri, 21 Oct 2022 15:22:43 +0300
 
 nicotine (3.2.5-1) jammy; urgency=medium
 

--- a/pynicotine/chatrooms.py
+++ b/pynicotine/chatrooms.py
@@ -99,8 +99,6 @@ class ChatRooms:
         if self.ui_callback:
             self.ui_callback.remove_room(room)
 
-        self.core.pluginhandler.leave_chatroom_notification(room)
-
     def clear_messages(self, room):
         if self.ui_callback:
             self.ui_callback.clear_messages(room)
@@ -203,6 +201,8 @@ class ChatRooms:
 
         if self.ui_callback:
             self.ui_callback.leave_room(msg)
+
+        self.core.pluginhandler.leave_chatroom_notification(msg.room)
 
     def get_user_status(self, msg):
         """ Server code: 7 """

--- a/pynicotine/cli/application.py
+++ b/pynicotine/cli/application.py
@@ -141,7 +141,7 @@ class Application:
         # Not implemented
         pass
 
-    def confirm_quit(self):
+    def confirm_quit(self, _remember):
         # Not implemented
         pass
 

--- a/pynicotine/gtkgui/__init__.py
+++ b/pynicotine/gtkgui/__init__.py
@@ -97,6 +97,9 @@ def run_gui(core, hidden, ci_mode, multi_instance):
         os.environ["GSETTINGS_SCHEMA_DIR"] = os.path.join(executable_folder, "lib/schemas")
 
     if sys.platform == "win32":
+        # Disable client-side decorations when header bar is disabled
+        os.environ["GTK_CSD"] = "0"
+
         # 'win32' PangoCairo backend on Windows is too slow, use 'fontconfig' instead
         os.environ["PANGOCAIRO_BACKEND"] = "fontconfig"
 

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -941,7 +941,11 @@ class ChatRoom:
     def echo_message(self, text, message_type):
 
         tag = self.tag_action
-        timestamp_format = config.sections["logging"]["rooms_timestamp"]
+
+        if message_type != "echo":
+            timestamp_format = config.sections["logging"]["rooms_timestamp"]
+        else:
+            timestamp_format = False
 
         if hasattr(self, "tag_" + str(message_type)):
             tag = getattr(self, "tag_" + str(message_type))

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -441,7 +441,11 @@ class PrivateChat:
     def echo_message(self, text, message_type):
 
         tag = self.tag_local
-        timestamp_format = config.sections["logging"]["private_timestamp"]
+
+        if message_type != "echo":
+            timestamp_format = config.sections["logging"]["private_timestamp"]
+        else:
+            timestamp_format = False
 
         if hasattr(self, "tag_" + str(message_type)):
             tag = getattr(self, "tag_" + str(message_type))

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -446,6 +446,7 @@ class PrivateChat:
             timestamp_format = config.sections["logging"]["private_timestamp"]
         else:
             timestamp_format = False
+            tag = self.tag_action
 
         if hasattr(self, "tag_" + str(message_type)):
             tag = getattr(self, "tag_" + str(message_type))

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -45,6 +45,7 @@ from pynicotine.gtkgui.widgets.treeview import save_columns
 from pynicotine.gtkgui.widgets.treeview import select_user_row_iter
 from pynicotine.gtkgui.widgets.treeview import show_file_path_tooltip
 from pynicotine.gtkgui.widgets.ui import UserInterface
+from pynicotine.slskmessages import UINT64_LIMIT
 from pynicotine.transfers import Transfer
 from pynicotine.utils import human_length
 from pynicotine.utils import human_size
@@ -427,6 +428,8 @@ class TransferList:
             iterator = self.transfersmodel.iter_next(iterator)
 
         transfer = self.transfersmodel.get_value(initer, 16)
+        total_size = min(total_size, UINT64_LIMIT)
+        current_bytes = min(current_bytes, UINT64_LIMIT)
 
         if transfer.status != salient_status:
             self.transfersmodel.set_value(initer, 3, self.translate_status(salient_status))

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -25,7 +25,6 @@
 import time
 
 from collections import OrderedDict
-from sys import maxsize
 
 from gi.repository import GObject
 from gi.repository import Gtk
@@ -389,20 +388,6 @@ class TransferList:
     def get_percent(current_byte_offset, size):
         return min(((100 * int(current_byte_offset)) / int(size)), 100) if size > 0 else 100
 
-    @staticmethod
-    def get_size(size):
-
-        try:
-            size = int(size)
-
-            if size < 0 or size > maxsize:
-                size = 0
-
-        except TypeError:
-            size = 0
-
-        return size
-
     def update_parent_row(self, initer, key, folder=False):
 
         speed = 0.0
@@ -436,7 +421,7 @@ class TransferList:
                 continue
 
             elapsed += transfer.time_elapsed or 0
-            total_size += self.get_size(transfer.size)
+            total_size += transfer.size or 0
             current_bytes += transfer.current_byte_offset or 0
 
             iterator = self.transfersmodel.iter_next(iterator)
@@ -453,7 +438,7 @@ class TransferList:
             transfer.speed = speed
 
         if transfer.time_elapsed != elapsed:
-            left = (total_size - current_bytes) / speed if speed > 0 else 0
+            left = (total_size - current_bytes) / speed if speed and total_size > current_bytes else 0
             self.transfersmodel.set_value(initer, 8, self.get_helapsed(elapsed))
             self.transfersmodel.set_value(initer, 9, self.get_hleft(left))
             self.transfersmodel.set_value(initer, 14, elapsed)
@@ -482,7 +467,7 @@ class TransferList:
             # Priority status
             status = status + " (%s)" % modifier
 
-        size = self.get_size(transfer.size)
+        size = transfer.size or 0
         speed = transfer.speed or 0
         hspeed = self.get_hspeed(speed)
         elapsed = transfer.time_elapsed or 0

--- a/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
@@ -47,6 +47,7 @@
                 <property name="selectable">True</property>
                 <property name="halign">center</property>
                 <property name="justify">center</property>
+                <property name="max-width-chars">30</property>
                 <property name="wrap">True</property>
                 <style>
                   <class name="title-1"/>
@@ -303,6 +304,9 @@
                 <property name="label" translatable="yes">Download Files to Folder</property>
                 <property name="halign">center</property>
                 <property name="selectable">True</property>
+                <property name="justify">center</property>
+                <property name="max-width-chars">60</property>
+                <property name="wrap">True</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -327,6 +331,9 @@
                 <property name="label" translatable="yes">Share Folders</property>
                 <property name="halign">center</property>
                 <property name="selectable">True</property>
+                <property name="justify">center</property>
+                <property name="max-width-chars">60</property>
+                <property name="wrap">True</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -502,6 +509,7 @@
                 <property name="selectable">True</property>
                 <property name="halign">center</property>
                 <property name="justify">center</property>
+                <property name="max-width-chars">30</property>
                 <property name="wrap">True</property>
                 <style>
                   <class name="title-1"/>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -348,8 +348,8 @@
                                             <child>
                                               <object class="GtkButton" id="_download_users_button">
                                                 <property name="visible">True</property>
-                                                <property name="action-name">app.transfer-statistics</property>
                                                 <property name="tooltip-text" translatable="yes">Users</property>
+                                                <signal name="clicked" handler="on_transfer_statistics"/>
                                                 <child>
                                                   <object class="GtkLabel" id="download_users_label">
                                                     <property name="visible">True</property>
@@ -389,8 +389,8 @@
                                             <child>
                                               <object class="GtkButton" id="_download_files_button">
                                                 <property name="visible">True</property>
-                                                <property name="action-name">app.transfer-statistics</property>
                                                 <property name="tooltip-text" translatable="yes">Files</property>
+                                                <signal name="clicked" handler="on_transfer_statistics"/>
                                                 <child>
                                                   <object class="GtkLabel" id="download_files_label">
                                                     <property name="visible">True</property>
@@ -591,8 +591,8 @@
                                             <child>
                                               <object class="GtkButton" id="_upload_users_button">
                                                 <property name="visible">True</property>
-                                                <property name="action-name">app.transfer-statistics</property>
                                                 <property name="tooltip-text" translatable="yes">Users</property>
+                                                <signal name="clicked" handler="on_transfer_statistics"/>
                                                 <child>
                                                   <object class="GtkLabel" id="upload_users_label">
                                                     <property name="visible">True</property>
@@ -632,8 +632,8 @@
                                             <child>
                                               <object class="GtkButton" id="_upload_files_button">
                                                 <property name="visible">True</property>
-                                                <property name="action-name">app.transfer-statistics</property>
                                                 <property name="tooltip-text" translatable="yes">Files</property>
+                                                <signal name="clicked" handler="on_transfer_statistics"/>
                                                 <child>
                                                   <object class="GtkLabel" id="upload_files_label">
                                                     <property name="visible">True</property>
@@ -1731,7 +1731,7 @@
                   <object class="GtkButton" id="_connections_button">
                     <property name="visible">True</property>
                     <property name="tooltip-text" translatable="yes">Connections</property>
-                    <property name="action-name">app.transfer-statistics</property>
+                    <signal name="clicked" handler="on_transfer_statistics"/>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -1842,7 +1842,7 @@
                 <child>
                   <object class="GtkButton" id="user_status_button">
                     <property name="visible">True</property>
-                    <property name="action-name">app.away</property>
+                    <signal name="clicked" handler="on_away"/>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>

--- a/pynicotine/gtkgui/widgets/infobar.py
+++ b/pynicotine/gtkgui/widgets/infobar.py
@@ -27,7 +27,8 @@ class InfoBar:
 
         self.info_bar = info_bar
         self.revealer = self.info_bar.get_ancestor(Gtk.Revealer)
-        self.label = Gtk.Label(height_request=24, margin_start=3, margin_end=3, wrap=True, visible=True, xalign=0)
+        self.label = Gtk.Label(height_request=24, hexpand=True, margin_start=3, margin_end=3, wrap=True,
+                               visible=True, xalign=0)
 
         if button is not None:
             self.info_bar.add_action_widget(button, Gtk.ResponseType.NONE)
@@ -40,6 +41,7 @@ class InfoBar:
         self.set_visible(False)
 
     def set_visible(self, visible):
+        self.info_bar.set_visible(visible)
         self.revealer.set_reveal_child(visible)
 
     def show_message(self, message, message_type=Gtk.MessageType.INFO):

--- a/pynicotine/gtkgui/widgets/notifications.py
+++ b/pynicotine/gtkgui/widgets/notifications.py
@@ -17,10 +17,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-import threading
 import time
 
 from ctypes import Structure, byref, sizeof
+from threading import Thread
 
 from gi.repository import Gdk
 from gi.repository import Gio
@@ -190,9 +190,7 @@ class WinNotify:
         if self.worker and self.worker.is_alive():
             return
 
-        self.worker = threading.Thread(target=self.work)
-        self.worker.name = "WinNotify"
-        self.worker.daemon = True
+        self.worker = Thread(target=self.work, name="WinNotify", daemon=True)
         self.worker.start()
 
     def work(self):

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -104,19 +104,23 @@ class ChatEntry:
         cmd_split = text.split(maxsplit=1)
         cmd = cmd_split[0]
 
-        # Clear chat entry
-        self.entry.set_text("")
-
         if len(cmd_split) == 2:
             args = cmd_split[1]
         else:
             args = ""
 
+        # Allow the command line to be edited if parsing rejects the line or if the plugin returns False
         if self.is_chatroom:
-            self.core.pluginhandler.trigger_chatroom_command_event(self.entity, cmd[1:], args)
+            if not self.core.pluginhandler.trigger_chatroom_command_event(self.entity, cmd[1:], args):
+                self.entry.grab_focus()
+                return
+
+        elif not self.core.pluginhandler.trigger_private_chat_command_event(self.entity, cmd[1:], args):
+            self.entry.grab_focus()
             return
 
-        self.core.pluginhandler.trigger_private_chat_command_event(self.entity, cmd[1:], args)
+        # Clear chat entry
+        self.entry.set_text("")
 
     def on_tab_complete_accelerator(self, widget, state, backwards=False):
         """ Tab and Shift+Tab: tab complete chat """

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -446,6 +446,8 @@ class Plugin(BasePlugin):
             for command in commands:
                 self.echo_message(command)
 
+        return ("To search for a command, type /help [command]")
+
     """ "Chats" """
 
     def clear_command(self, _args, user=None, room=None):
@@ -455,6 +457,8 @@ class Plugin(BasePlugin):
 
         elif user is not None:
             self.core.privatechats.clear_messages(user)
+
+        return 0
 
     def close_command(self, args, user=None, **_unused):
 
@@ -468,6 +472,8 @@ class Plugin(BasePlugin):
 
         self.core.privatechats.remove_user(user)
 
+        return 0
+
     def ctcpversion_command(self, args, user=None, **_unused):
 
         if args:
@@ -480,10 +486,12 @@ class Plugin(BasePlugin):
             self.echo_message("Asked %s for client version" % user)
 
     def hello_command(self, args, **_unused):
-        self.echo_message("Hello there! %s" % args)
+        return ("Hello there! %s" % args)
 
     def join_chat_command(self, args, **_unused):
         self.core.chatrooms.show_room(args)
+
+        return 0  # don't let a None echo steal the tab back again
 
     def leave_command(self, args, room=None, **_unused):
 
@@ -499,17 +507,21 @@ class Plugin(BasePlugin):
     def me_chat_command(self, args, **_unused):
         self.send_message("/me " + args)
 
+        return 0  # don't need any echo if we're chatting
+
     def msg_chat_command(self, args, **_unused):
 
         args_split = args.split(" ", maxsplit=1)
         user, text = args_split[0], args_split[1]
 
         if self.send_private(user, text, show_ui=True, switch_page=False):
-            self.echo_message("Private message sent to user %s" % user)
+            return ("Private message sent to user %s" % user)
 
     def pm_chat_command(self, args, **_unused):
         self.core.privatechats.show_user(args)
         self.log("Private chat with user %s" % args)
+
+        return 0  # don't let a None echo steal the tab back again (hence the use of log above instead of echo_message)
 
     def say_chat_command(self, args, **_unused):
 
@@ -517,7 +529,7 @@ class Plugin(BasePlugin):
         room, text = args_split[0], args_split[1]
 
         if self.send_public(room, text):
-            self.log("Chat message sent to room %s" % room)
+            return ("Chat message sent to room %s" % room)
 
     """ "Shares" """
 
@@ -548,6 +560,7 @@ class Plugin(BasePlugin):
         if args:
             user = args
 
+        # TODO: None of the user commands return anything
         return self.core.userlist.add_user(user)
 
     def remove_buddy_command(self, args, user=None, **_unused):
@@ -632,21 +645,28 @@ class Plugin(BasePlugin):
         if args:
             user = args
 
+        # Echoing the IP will be difficult because it waits for a server response message
+        # could we use a user_resolve_notification() or similar?
         return self.core.request_ip_address(user)
+
+    def user_resolve_notification(self, _user, _ip_address, _port, _country):
+        pass  # TODO: this wont work, we need request_ip_address_response_notification()
 
     def whois_user_command(self, args, user=None, **_unused):
 
         if args:
             user = args
 
-        return self.core.userinfo.request_user_info(user)
+        self.core.userinfo.request_user_info(user)  # TODO: returns None which blocks the switch tab
+        return 0
 
     def browse_user_command(self, args, user=None, **_unused):
 
         if args:
             user = args
 
-        return self.core.userbrowse.browse_user(user)
+        self.core.userbrowse.browse_user(user)  # TODO: returns None which blocks the switch tab
+        return 0
 
     """ General purpose "Commands" """
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -103,7 +103,20 @@ class Plugin(BasePlugin):
                 "description": _("Ask for a user's client version"),
                 "usage": ["[user]"],
                 "group": _("Client-To-Client Protocol")
-            }
+            },
+            "ipignore": {  # new untested
+                "callback": self.ignore_ip_command,
+                "description": _("Silence chat from anyone at IP address"),
+                "usage": ["<ip_address>"],
+                "group": None
+            },
+            "ipunignore": {  # new untested
+                "callback": self.unignore_ip_command,
+                "description": _("Remove IP address from chat ignore list"),
+                "usage": ["<ip_address>"],
+                "group": None
+            },
+
         }
 
         chatroom_commands = {
@@ -120,7 +133,92 @@ class Plugin(BasePlugin):
                 "usage": ["[room]"],
                 "aliases": ["l"],
                 "group": _("Chat Rooms")
-            }
+            },
+            "add": {
+                "callback": self.add_buddy_command,
+                "description": _("Add user to buddy list"),
+                "usage": ["<user>"],
+                "aliases": ["buddy"],
+                "group": _("User")
+            },
+            "rem": {
+                "callback": self.remove_buddy_command,
+                "description": _("Remove user from buddy list"),
+                "usage": ["<buddy>"],
+                "aliases": ["unbuddy"],
+                "group": _("User")
+            },
+            "ban": {
+                "callback": self.ban_user_command,
+                "description": _("Stop file transfers to user"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "unban": {
+                "callback": self.unban_user_command,
+                "description": _("Remove user from ban list"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "block": {  # new
+                "callback": self.block_user_ip_command,
+                "description": _("Stop file transfers to IP of user"),
+                "usage": ["<user>"],
+                "aliases": ["banip"],  # new
+                "group": _("User")
+            },
+            "unblock": {  # new
+                "callback": self.unban_user_command,
+                "description": _("Remove user from IP block list"),
+                "usage": ["<user>"],
+                "aliases": ["unbanip"],  # new
+                "group": _("User")
+            },
+            "ignore": {
+                "callback": self.ignore_user_command,
+                "description": _("Silence chat messages from user"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "unignore": {
+                "callback": self.unignore_user_command,
+                "description": _("Remove user from ignore list"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "ignoreip": {
+                "callback": self.ignore_user_ip_command,
+                "description": _("Silence chat messages from IP address of user"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "unignoreip": {  # new
+                "callback": self.unignore_user_ip_command,
+                "description": _("Remove user's IP address from chat ignore list"),
+                "usage": ["<user>"],
+                "group": None
+            },
+            "ip": {
+                "callback": self.ip_user_command,
+                "description": _("Show IP address of user"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "whois": {
+                "callback": self.whois_user_command,
+                "description": _("Show info about user"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+
+            "browse": {
+                "callback": self.browse_user_command,
+                "description": _("Browse files of user"),
+                "usage": ["<user>"],
+                "aliases": ["b"],
+                "group": _("User")
+            },
+
         }
 
         private_chat_commands = {
@@ -137,7 +235,93 @@ class Plugin(BasePlugin):
                 "usage": ["<room>"],
                 "aliases": ["l"],
                 "group": _("Chat Rooms")
-            }
+            },
+            "add": {
+                "callback": self.add_buddy_command,
+                "description": _("Add user to buddy list"),
+                "usage": ["[user]"],
+                "aliases": ["buddy"],
+                "group": _("User")
+            },
+            "rem": {
+                "callback": self.remove_buddy_command,
+                "description": _("Remove user from buddy list"),
+                "usage": ["[buddy]"],
+                "aliases": ["unbuddy"],
+                "group": _("User")
+            },
+            "ban": {
+                "callback": self.ban_user_command,
+                "description": _("Stop file transfers to user"),
+                "usage": ["[user]"],
+                "group": _("User")
+            },
+            "unban": {
+                "callback": self.unban_user_command,
+                "description": _("Remove user from ban list"),
+                "usage": ["[user]"],
+                "group": _("User")
+            },
+            "block": {  # new
+                "callback": self.block_user_ip_command,
+                "description": _("Stop file transfers to IP of user"),
+                "usage": ["[user]"],
+                "aliases": ["banip"],  # new
+                "group": _("User")
+            },
+            "unblock": {  # new
+                "callback": self.unblock_user_ip_command,
+                "description": _("Remove user from IP block list"),
+                "usage": ["[user]"],
+                "aliases": ["unbanip"],  # new
+                "group": _("User")
+            },
+            "ignore": {
+                "callback": self.ignore_user_command,
+                "description": _("Silence chat messages from user"),
+                "usage": ["[user]"],
+                "group": _("User")
+            },
+            "unignore": {
+                "callback": self.unignore_user_command,
+                "description": _("Remove user from ignore list"),
+                "usage": ["[user"],
+                "group": _("User")
+            },
+            "ignoreip": {
+                "callback": self.ignore_user_ip_command,
+                "description": _("Silence chat messages from IP address of user"),
+                "usage": ["[user]"],
+                "group": _("User")
+            },
+            "unignoreip": {
+                "callback": self.unignore_user_ip_command,
+                "description": _("Remove user's IP address from ignore list"),
+                "usage": ["[user]"],
+                "group": _("User")
+            },
+            "ip": {
+                "callback": self.ip_user_command,
+                "description": _("Show IP address of user"),
+                "usage": ["[user]"],
+                "group": _("User")
+            },
+            "whois": {
+                "callback": self.whois_user_command,
+                "description": _("Show info about user"),
+                "usage": ["[user]"],
+                "aliases": ["info"],  # new
+                "group": _("User")
+            },
+
+            "browse": {
+                "callback": self.browse_user_command,
+                "description": _("Browse files of user"),
+                "usage": ["[user]"],
+                "aliases": ["b"],
+                "group": _("User")
+            },
+
         }
 
         cli_commands = {
@@ -159,7 +343,48 @@ class Plugin(BasePlugin):
                 "callback": self.list_shares_command,
                 "description": _("List shares"),
                 "group": _("Shares")
-            }
+            },
+            "add": {
+                "callback": self.add_buddy_command,
+                "description": _("Add user to buddy list"),
+                "usage": ["<user>"],
+                "aliases": ["buddy"],
+                "group": _("User")
+            },
+            "rem": {
+                "callback": self.remove_buddy_command,
+                "description": _("Remove user from buddy list"),
+                "usage": ["<buddy>"],
+                "aliases": ["unbuddy"],
+                "group": _("User")
+            },
+            "ban": {
+                "callback": self.ban_user_command,
+                "description": _("Stop file transfers to user"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "unban": {
+                "callback": self.unban_user_command,
+                "description": _("Remove user from ban list"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "block": {  # new untested
+                "callback": self.block_user_ip_command,
+                "description": _("Stop file transfers to IP of user"),
+                "usage": ["<user>"],
+                "aliases": ["banip"],  # new
+                "group": None
+            },
+            "unblock": {  # new untested
+                "callback": self.unblock_user_ip_command,
+                "description": _("Remove user from IP block list"),
+                "usage": ["<user>"],
+                "aliases": ["unbanip"],  # new
+                "group": None
+            },
+
         }
 
         self.chatroom_commands = {**commands, **chat_commands, **chatroom_commands}
@@ -194,6 +419,11 @@ class Plugin(BasePlugin):
 
             description = data.get("description", "No description")
             group = data.get("group", _("Commands"))
+
+            if group is None:
+                # Hidden command
+                continue
+
             group_words = group.lower().split(" ")
 
             if not args or query in command or query in (a for a in aliases) or query in group_words:
@@ -215,6 +445,8 @@ class Plugin(BasePlugin):
 
             for command in commands:
                 self.echo_message(command)
+
+    """ "Chats" """
 
     def clear_command(self, _args, user=None, room=None):
 
@@ -287,6 +519,8 @@ class Plugin(BasePlugin):
         if self.send_public(room, text):
             self.log("Chat message sent to room %s" % room)
 
+    """ "Shares" """
+
     def add_share_command(self, args):
 
         args_split = args.split(" ", maxsplit=3)  # "\""
@@ -306,6 +540,115 @@ class Plugin(BasePlugin):
 
     def rescan_command(self, _args, **_unused):
         self.core.shares.rescan_shares()
+
+    """ "User" """
+
+    def add_buddy_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.userlist.add_user(user)
+
+    def remove_buddy_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.userlist.remove_user(user)
+
+    def ban_user_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.network_filter.ban_user(user)
+
+    def unban_user_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.network_filter.unban_user(user)
+
+    def block_user_ip_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.network_filter.block_user_ip(user)
+
+    def unblock_user_ip_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.network_filter.unblock_user_ip(user)
+
+    def unban_user_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.network_filter.unban_user(user)
+
+    def ignore_user_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.network_filter.ignore_user(user)
+
+    def unignore_user_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.network_filter.unignore_user(user)
+
+    def ignore_user_ip_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.network_filter.ignore_user_ip(user)
+
+    def unignore_user_ip_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.network_filter.unignore_user_ip(user)
+
+    def ignore_ip_command(self, args, **_unused):
+        return self.core.network_filter.ignore_ip(args)
+
+    def unignore_ip_command(self, args, **_unused):
+        # TODO: self.core.network_filter.unignore_ip(ip_address)
+        self.echo_message(f"nothing here yet, you entered: {args}")
+
+    def ip_user_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.request_ip_address(user)
+
+    def whois_user_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.userinfo.request_user_info(user)
+
+    def browse_user_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        return self.core.userbrowse.browse_user(user)
+
+    """ General purpose "Commands" """
 
     def away_command(self, _args, **_unused):
         self.core.set_away_mode(self.core.user_status != 1, save_state=True)  # 1 = UserStatus.AWAY

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -55,7 +55,69 @@ class Plugin(BasePlugin):
                 "usage": ["[force]"],
                 "choices": ["force"],
                 "aliases": ["q", "exit"]
-            }
+            },
+
+            "add": {
+                "callback": self.add_buddy_command,
+                "description": _("Add user to buddy list"),
+                "usage": ["<user>"],
+                "aliases": ["buddy"],
+                "group": _("User")
+            },
+            "rem": {
+                "callback": self.remove_buddy_command,
+                "description": _("Remove user from buddy list"),
+                "usage": ["<buddy>"],
+                "aliases": ["unbuddy"],
+                "group": _("User")
+            },
+            "ban": {
+                "callback": self.ban_user_command,
+                "description": _("Stop file transfers to user"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "unban": {
+                "callback": self.unban_user_command,
+                "description": _("Remove user from ban list"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "block": {  # new untested
+                "callback": self.block_user_ip_command,
+                "description": _("Stop all connections from same IP as user"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+            "unblock": {  # new untested
+                "callback": self.unblock_user_ip_command,
+                "description": _("Remove user's IP address from block list"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+
+            "ip": {
+                "callback": self.ip_user_command,
+                "description": _("Show IP address of user"),
+                "usage": ["<user>"],
+                "group": _("User")
+            },
+
+            "whois": {
+                "callback": self.whois_user_command,
+                "description": _("Show info about user"),
+                "usage": ["<user>"],
+                "aliases": ["info"],  # new
+                "group": _("User")
+            },
+            "browse": {
+                "callback": self.browse_user_command,
+                "description": _("Browse files of user"),
+                "usage": ["<user>"],
+                "aliases": ["b"],
+                "group": _("User")
+            },
+
         }
 
         chat_commands = {
@@ -104,76 +166,7 @@ class Plugin(BasePlugin):
                 "usage": ["[user]"],
                 "group": _("Client-To-Client Protocol")
             },
-            "ipignore": {  # new untested
-                "callback": self.ignore_ip_command,
-                "description": _("Silence chat from anyone at IP address"),
-                "usage": ["<ip_address>"],
-                "group": None
-            },
-            "ipunignore": {  # new untested
-                "callback": self.unignore_ip_command,
-                "description": _("Remove IP address from chat ignore list"),
-                "usage": ["<ip_address>"],
-                "group": None
-            },
 
-        }
-
-        chatroom_commands = {
-            "close": {
-                "callback": self.close_command,
-                "description": _("Close private chat"),
-                "usage": ["<user>"],
-                "aliases": ["c"],
-                "group": _("Private Chat")
-            },
-            "leave": {
-                "callback": self.leave_command,
-                "description": _("Leave chat room"),
-                "usage": ["[room]"],
-                "aliases": ["l"],
-                "group": _("Chat Rooms")
-            },
-            "add": {
-                "callback": self.add_buddy_command,
-                "description": _("Add user to buddy list"),
-                "usage": ["<user>"],
-                "aliases": ["buddy"],
-                "group": _("User")
-            },
-            "rem": {
-                "callback": self.remove_buddy_command,
-                "description": _("Remove user from buddy list"),
-                "usage": ["<buddy>"],
-                "aliases": ["unbuddy"],
-                "group": _("User")
-            },
-            "ban": {
-                "callback": self.ban_user_command,
-                "description": _("Stop file transfers to user"),
-                "usage": ["<user>"],
-                "group": _("User")
-            },
-            "unban": {
-                "callback": self.unban_user_command,
-                "description": _("Remove user from ban list"),
-                "usage": ["<user>"],
-                "group": _("User")
-            },
-            "block": {  # new
-                "callback": self.block_user_ip_command,
-                "description": _("Stop file transfers to IP of user"),
-                "usage": ["<user>"],
-                "aliases": ["banip"],  # new
-                "group": _("User")
-            },
-            "unblock": {  # new
-                "callback": self.unban_user_command,
-                "description": _("Remove user from IP block list"),
-                "usage": ["<user>"],
-                "aliases": ["unbanip"],  # new
-                "group": _("User")
-            },
             "ignore": {
                 "callback": self.ignore_user_command,
                 "description": _("Silence chat messages from user"),
@@ -196,27 +189,38 @@ class Plugin(BasePlugin):
                 "callback": self.unignore_user_ip_command,
                 "description": _("Remove user's IP address from chat ignore list"),
                 "usage": ["<user>"],
-                "group": None
-            },
-            "ip": {
-                "callback": self.ip_user_command,
-                "description": _("Show IP address of user"),
-                "usage": ["<user>"],
-                "group": _("User")
-            },
-            "whois": {
-                "callback": self.whois_user_command,
-                "description": _("Show info about user"),
-                "usage": ["<user>"],
                 "group": _("User")
             },
 
-            "browse": {
-                "callback": self.browse_user_command,
-                "description": _("Browse files of user"),
-                "usage": ["<user>"],
-                "aliases": ["b"],
+            "ipignore": {  # new untested
+                "callback": self.ignore_ip_command,
+                "description": _("Silence chat from anyone at IP address"),
+                "usage": ["<ip_address>"],
                 "group": _("User")
+            },
+            "ipunignore": {  # new untested
+                "callback": self.unignore_ip_command,
+                "description": _("Remove IP address from chat ignore list"),
+                "usage": ["<ip_address>"],
+                "group": _("User")
+            },
+
+        }
+
+        chatroom_commands = {
+            "close": {
+                "callback": self.close_command,
+                "description": _("Close private chat"),
+                "usage": ["<user>"],
+                "aliases": ["c"],
+                "group": _("Private Chat")
+            },
+            "leave": {
+                "callback": self.leave_command,
+                "description": _("Leave chat room"),
+                "usage": ["[room]"],
+                "aliases": ["l"],
+                "group": _("Chat Rooms")
             },
 
         }
@@ -236,6 +240,7 @@ class Plugin(BasePlugin):
                 "aliases": ["l"],
                 "group": _("Chat Rooms")
             },
+
             "add": {
                 "callback": self.add_buddy_command,
                 "description": _("Add user to buddy list"),
@@ -264,7 +269,7 @@ class Plugin(BasePlugin):
             },
             "block": {  # new
                 "callback": self.block_user_ip_command,
-                "description": _("Stop file transfers to IP of user"),
+                "description": _("Stop connections to IP of user"),
                 "usage": ["[user]"],
                 "aliases": ["banip"],  # new
                 "group": _("User")
@@ -285,7 +290,7 @@ class Plugin(BasePlugin):
             "unignore": {
                 "callback": self.unignore_user_command,
                 "description": _("Remove user from ignore list"),
-                "usage": ["[user"],
+                "usage": ["[user]"],
                 "group": _("User")
             },
             "ignoreip": {
@@ -294,18 +299,20 @@ class Plugin(BasePlugin):
                 "usage": ["[user]"],
                 "group": _("User")
             },
-            "unignoreip": {
+            "unignoreip": {  # new
                 "callback": self.unignore_user_ip_command,
-                "description": _("Remove user's IP address from ignore list"),
+                "description": _("Remove user's IP address from chat ignore list"),
                 "usage": ["[user]"],
                 "group": _("User")
             },
+
             "ip": {
                 "callback": self.ip_user_command,
                 "description": _("Show IP address of user"),
                 "usage": ["[user]"],
                 "group": _("User")
             },
+
             "whois": {
                 "callback": self.whois_user_command,
                 "description": _("Show info about user"),
@@ -313,7 +320,6 @@ class Plugin(BasePlugin):
                 "aliases": ["info"],  # new
                 "group": _("User")
             },
-
             "browse": {
                 "callback": self.browse_user_command,
                 "description": _("Browse files of user"),
@@ -343,46 +349,6 @@ class Plugin(BasePlugin):
                 "callback": self.list_shares_command,
                 "description": _("List shares"),
                 "group": _("Shares")
-            },
-            "add": {
-                "callback": self.add_buddy_command,
-                "description": _("Add user to buddy list"),
-                "usage": ["<user>"],
-                "aliases": ["buddy"],
-                "group": _("User")
-            },
-            "rem": {
-                "callback": self.remove_buddy_command,
-                "description": _("Remove user from buddy list"),
-                "usage": ["<buddy>"],
-                "aliases": ["unbuddy"],
-                "group": _("User")
-            },
-            "ban": {
-                "callback": self.ban_user_command,
-                "description": _("Stop file transfers to user"),
-                "usage": ["<user>"],
-                "group": _("User")
-            },
-            "unban": {
-                "callback": self.unban_user_command,
-                "description": _("Remove user from ban list"),
-                "usage": ["<user>"],
-                "group": _("User")
-            },
-            "block": {  # new untested
-                "callback": self.block_user_ip_command,
-                "description": _("Stop file transfers to IP of user"),
-                "usage": ["<user>"],
-                "aliases": ["banip"],  # new
-                "group": None
-            },
-            "unblock": {  # new untested
-                "callback": self.unblock_user_ip_command,
-                "description": _("Remove user from IP block list"),
-                "usage": ["<user>"],
-                "aliases": ["unbanip"],  # new
-                "group": None
             },
 
         }
@@ -419,11 +385,6 @@ class Plugin(BasePlugin):
 
             description = data.get("description", "No description")
             group = data.get("group", _("Commands"))
-
-            if group is None:
-                # Hidden command
-                continue
-
             group_words = group.lower().split(" ")
 
             if not args or query in command or query in (a for a in aliases) or query in group_words:
@@ -598,13 +559,6 @@ class Plugin(BasePlugin):
 
         return self.core.network_filter.unblock_user_ip(user)
 
-    def unban_user_command(self, args, user=None, **_unused):
-
-        if args:
-            user = args
-
-        return self.core.network_filter.unban_user(user)
-
     def ignore_user_command(self, args, user=None, **_unused):
 
         if args:
@@ -633,13 +587,6 @@ class Plugin(BasePlugin):
 
         return self.core.network_filter.unignore_user_ip(user)
 
-    def ignore_ip_command(self, args, **_unused):
-        return self.core.network_filter.ignore_ip(args)
-
-    def unignore_ip_command(self, args, **_unused):
-        # TODO: self.core.network_filter.unignore_ip(ip_address)
-        self.echo_message(f"nothing here yet, you entered: {args}")
-
     def ip_user_command(self, args, user=None, **_unused):
 
         if args:
@@ -649,8 +596,12 @@ class Plugin(BasePlugin):
         # could we use a user_resolve_notification() or similar?
         return self.core.request_ip_address(user)
 
-    def user_resolve_notification(self, _user, _ip_address, _port, _country):
-        pass  # TODO: this wont work, we need request_ip_address_response_notification()
+    def ignore_ip_command(self, args, **_unused):
+        return self.core.network_filter.ignore_ip(args)
+
+    def unignore_ip_command(self, args, **_unused):
+        # TODO: self.core.network_filter.unignore_ip(ip_address)
+        self.echo_message(f"nothing here yet, you entered: {args}")
 
     def whois_user_command(self, args, user=None, **_unused):
 
@@ -668,7 +619,7 @@ class Plugin(BasePlugin):
         self.core.userbrowse.browse_user(user)  # TODO: returns None which blocks the switch tab
         return 0
 
-    """ General purpose "Commands" """
+    """ General "Commands" """
 
     def away_command(self, _args, **_unused):
         self.core.set_away_mode(self.core.user_status != 1, save_state=True)  # 1 = UserStatus.AWAY

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -35,6 +35,8 @@ class Plugin(BasePlugin):
             "rescan": {
                 "callback": self.rescan_command,
                 "description": _("Rescan shares"),
+                "usage": ["[force]"],
+                "choices": ["force"],
                 "group": _("Shares")
             },
             "hello": {
@@ -304,8 +306,13 @@ class Plugin(BasePlugin):
     def list_shares_command(self, args):
         self.echo_message(f"nothing here yet, you entered: {args}")
 
-    def rescan_command(self, _args, **_unused):
-        self.core.shares.rescan_shares()
+    def rescan_command(self, args, **_unused):
+
+        if args:
+            self.echo_message(f"Force rescan is not implemented here yet, you entered: {args}")
+            return
+
+        self.core.shares.rescan_shares()  # TODO: force=args)  # see shares.py in verify-dirs branch
 
     def away_command(self, _args, **_unused):
         self.core.set_away_mode(self.core.user_status != 1, save_state=True)  # 1 = UserStatus.AWAY

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -52,8 +52,7 @@ class Plugin(BasePlugin):
             "quit": {
                 "callback": self.quit_command,
                 "description": _("Quit Nicotine+"),
-                "usage": ["[force]"],
-                "choices": ["force"],
+                "usage": ["[-force]", ""],  # "" disallow extra args
                 "aliases": ["q", "exit"]
             },
 
@@ -73,7 +72,7 @@ class Plugin(BasePlugin):
             },
             "ban": {
                 "callback": self.ban_user_command,
-                "description": _("Stop file transfers to user"),
+                "description": _("Stop connections from user"),
                 "usage": ["<user>"],
                 "group": _("Users")
             },
@@ -109,8 +108,8 @@ class Plugin(BasePlugin):
             "clear": {
                 "callback": self.clear_command,
                 "description": _("Clear chat window"),
+                "usage": [""],  # "" disallow any args
                 "aliases": ["cl"],
-                "choices": [-1],
                 "group": _("Chat")
             },
             "join": {
@@ -256,7 +255,7 @@ class Plugin(BasePlugin):
             },
             "ban": {
                 "callback": self.ban_user_command,
-                "description": _("Stop file transfers to user"),
+                "description": _("Stop connections from user"),
                 "usage": ["[user]"],
                 "group": _("Users")
             },
@@ -333,15 +332,13 @@ class Plugin(BasePlugin):
             "addshare": {
                 "callback": self.add_share_command,
                 "description": _("Add share"),
-                "usage": ["<public|private>", "<virtual_name>", "<path>"],
-                "choices": ["public", "private"],
+                "usage": ["<public|private|buddy>", "<virtual_name>", "<path>"],
                 "group": _("Shares")
             },
             "removeshare": {
                 "callback": self.remove_share_command,
                 "description": _("Remove share"),
-                "usage": ["<public|private>", "<virtual_name>"],
-                "choices": ["public", "private"],
+                "usage": ["<public|private|buddy>", "<virtual_name>"],
                 "group": _("Shares")
             },
             "listshares": {
@@ -401,7 +398,7 @@ class Plugin(BasePlugin):
 
         if not num_commands:
             self.echo_unknown_command(f"{prefix}{query}")
-            return None
+            return False
 
         output = f"Listing {num_commands} {interface} commands with <required> and [optional] arguments"
         output += " " + f"matching \"{query}\"" + ":" if query else ":"
@@ -432,12 +429,13 @@ class Plugin(BasePlugin):
         if args:
             user = args
 
-        if user in self.core.privatechats.users:
-            self.echo_message("Closing private chat of user %s" % user)
-        elif user:
+        if user not in self.core.privatechats.users:
             self.echo_message("Not messaging with user %s" % user)
+            return False
 
+        self.echo_message("Closing private chat of user %s" % user)
         self.core.privatechats.remove_user(user)
+        return True
 
     def ctcpversion_command(self, args, user=None, **_unused):
 
@@ -465,12 +463,13 @@ class Plugin(BasePlugin):
 
         if room not in self.core.chatrooms.joined_rooms:
             self.echo_message("Not joined in room %s" % room)
-            # return  # in future the gui might need to close a tab even if we are not joined, such as while offline etc
+            return False
 
         self.core.chatrooms.remove_room(room)
+        return True
 
     def me_chat_command(self, args, **_unused):
-        self.send_message("/me " + args)
+        return self.send_message("/me " + args)
 
     def msg_chat_command(self, args, **_unused):
 
@@ -500,17 +499,17 @@ class Plugin(BasePlugin):
 
     def add_share_command(self, args):
 
-        args_split = args.split(" ", maxsplit=3)  # "\""
-        access, name, path = args_split[0], args_split[1], args_split[2]
+        args_split = args.split(maxsplit=2)  # "\""
+        group, name, path = args_split[0], args_split[1], args_split[2]
 
-        self.echo_message(f"nothing here yet, you entered: access='{access}' name='{name}' path='{path}'")
+        self.echo_message(f"nothing here yet, you entered: group='{group}' name='{name}' path='{path}'")
 
     def remove_share_command(self, args):
 
-        args_split = args.split(" ", maxsplit=2)
-        access, name = args_split[0], args_split[1]
+        args_split = args.split(maxsplit=1)
+        group, name = args_split[0], args_split[1]
 
-        self.echo_message(f"nothing here yet, you entered: access='{access}' name='{name}'")
+        self.echo_message(f"nothing here yet, you entered: group='{group}' name='{name}'")
 
     def list_shares_command(self, args):
         self.echo_message(f"nothing here yet, you entered: {args}")

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -35,8 +35,7 @@ class Plugin(BasePlugin):
             "rescan": {
                 "callback": self.rescan_command,
                 "description": _("Rescan shares"),
-                "usage": ["[force]"],
-                "choices": ["force"],
+                "usage": ["[-force]"],
                 "group": _("Shares")
             },
             "hello": {

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -28,7 +28,7 @@ class Plugin(BasePlugin):
         commands = {
             "help": {
                 "callback": self.help_command,
-                "description": "Show commands",
+                "description": "List commands",
                 "usage": ["[query]"],
                 "aliases": ["?"]
             },
@@ -62,60 +62,45 @@ class Plugin(BasePlugin):
                 "description": _("Add user to buddy list"),
                 "usage": ["<user>"],
                 "aliases": ["buddy"],
-                "group": _("User")
+                "group": _("Users")
             },
             "rem": {
                 "callback": self.remove_buddy_command,
                 "description": _("Remove user from buddy list"),
                 "usage": ["<buddy>"],
                 "aliases": ["unbuddy"],
-                "group": _("User")
+                "group": _("Users")
             },
             "ban": {
                 "callback": self.ban_user_command,
                 "description": _("Stop file transfers to user"),
                 "usage": ["<user>"],
-                "group": _("User")
+                "group": _("Users")
             },
             "unban": {
                 "callback": self.unban_user_command,
                 "description": _("Remove user from ban list"),
                 "usage": ["<user>"],
-                "group": _("User")
+                "group": _("Users")
             },
             "block": {  # new untested
                 "callback": self.block_user_ip_command,
                 "description": _("Stop all connections from same IP as user"),
                 "usage": ["<user>"],
-                "group": _("User")
+                "group": _("Users")
             },
             "unblock": {  # new untested
                 "callback": self.unblock_user_ip_command,
                 "description": _("Remove user's IP address from block list"),
                 "usage": ["<user>"],
-                "group": _("User")
+                "group": _("Users")
             },
 
             "ip": {
                 "callback": self.ip_user_command,
                 "description": _("Show IP address of user"),
                 "usage": ["<user>"],
-                "group": _("User")
-            },
-
-            "whois": {
-                "callback": self.whois_user_command,
-                "description": _("Show info about user"),
-                "usage": ["<user>"],
-                "aliases": ["info"],  # new
-                "group": _("User")
-            },
-            "browse": {
-                "callback": self.browse_user_command,
-                "description": _("Browse files of user"),
-                "usage": ["<user>"],
-                "aliases": ["b"],
-                "group": _("User")
+                "group": _("Network Filters")
             },
 
         }
@@ -164,45 +149,59 @@ class Plugin(BasePlugin):
                 "callback": self.ctcpversion_command,
                 "description": _("Ask for a user's client version"),
                 "usage": ["[user]"],
-                "group": _("Client-To-Client Protocol")
             },
 
             "ignore": {
                 "callback": self.ignore_user_command,
                 "description": _("Silence chat messages from user"),
                 "usage": ["<user>"],
-                "group": _("User")
+                "group": _("Users")
             },
             "unignore": {
                 "callback": self.unignore_user_command,
                 "description": _("Remove user from ignore list"),
                 "usage": ["<user>"],
-                "group": _("User")
+                "group": _("Users")
             },
             "ignoreip": {
                 "callback": self.ignore_user_ip_command,
                 "description": _("Silence chat messages from IP address of user"),
                 "usage": ["<user>"],
-                "group": _("User")
+                "group": _("Users")
             },
             "unignoreip": {  # new
                 "callback": self.unignore_user_ip_command,
                 "description": _("Remove user's IP address from chat ignore list"),
                 "usage": ["<user>"],
-                "group": _("User")
+                "group": _("Users")
             },
 
             "ipignore": {  # new untested
                 "callback": self.ignore_ip_command,
                 "description": _("Silence chat from anyone at IP address"),
                 "usage": ["<ip_address>"],
-                "group": _("User")
+                "group": _("Network Filters")
             },
             "ipunignore": {  # new untested
                 "callback": self.unignore_ip_command,
                 "description": _("Remove IP address from chat ignore list"),
                 "usage": ["<ip_address>"],
-                "group": _("User")
+                "group": _("Network Filters")
+            },
+
+            "whois": {
+                "callback": self.whois_user_command,
+                "description": _("Show info about user"),
+                "usage": ["<user>"],
+                "aliases": ["info"],  # new
+                "group": _("Users")
+            },
+            "browse": {
+                "callback": self.browse_user_command,
+                "description": _("Browse files of user"),
+                "usage": ["<user>"],
+                "aliases": ["b"],
+                "group": _("Users")
             },
 
         }
@@ -246,71 +245,71 @@ class Plugin(BasePlugin):
                 "description": _("Add user to buddy list"),
                 "usage": ["[user]"],
                 "aliases": ["buddy"],
-                "group": _("User")
+                "group": _("Users")
             },
             "rem": {
                 "callback": self.remove_buddy_command,
                 "description": _("Remove user from buddy list"),
                 "usage": ["[buddy]"],
                 "aliases": ["unbuddy"],
-                "group": _("User")
+                "group": _("Users")
             },
             "ban": {
                 "callback": self.ban_user_command,
                 "description": _("Stop file transfers to user"),
                 "usage": ["[user]"],
-                "group": _("User")
+                "group": _("Users")
             },
             "unban": {
                 "callback": self.unban_user_command,
                 "description": _("Remove user from ban list"),
                 "usage": ["[user]"],
-                "group": _("User")
+                "group": _("Users")
             },
             "block": {  # new
                 "callback": self.block_user_ip_command,
                 "description": _("Stop connections to IP of user"),
                 "usage": ["[user]"],
                 "aliases": ["banip"],  # new
-                "group": _("User")
+                "group": _("Users")
             },
             "unblock": {  # new
                 "callback": self.unblock_user_ip_command,
                 "description": _("Remove user from IP block list"),
                 "usage": ["[user]"],
                 "aliases": ["unbanip"],  # new
-                "group": _("User")
+                "group": _("Users")
             },
             "ignore": {
                 "callback": self.ignore_user_command,
                 "description": _("Silence chat messages from user"),
                 "usage": ["[user]"],
-                "group": _("User")
+                "group": _("Users")
             },
             "unignore": {
                 "callback": self.unignore_user_command,
                 "description": _("Remove user from ignore list"),
                 "usage": ["[user]"],
-                "group": _("User")
+                "group": _("Users")
             },
             "ignoreip": {
                 "callback": self.ignore_user_ip_command,
                 "description": _("Silence chat messages from IP address of user"),
                 "usage": ["[user]"],
-                "group": _("User")
+                "group": _("Users")
             },
             "unignoreip": {  # new
                 "callback": self.unignore_user_ip_command,
                 "description": _("Remove user's IP address from chat ignore list"),
                 "usage": ["[user]"],
-                "group": _("User")
+                "group": _("Users")
             },
 
             "ip": {
                 "callback": self.ip_user_command,
                 "description": _("Show IP address of user"),
                 "usage": ["[user]"],
-                "group": _("User")
+                "group": _("Network Filters")
             },
 
             "whois": {
@@ -318,14 +317,14 @@ class Plugin(BasePlugin):
                 "description": _("Show info about user"),
                 "usage": ["[user]"],
                 "aliases": ["info"],  # new
-                "group": _("User")
+                "group": _("Users")
             },
             "browse": {
                 "callback": self.browse_user_command,
                 "description": _("Browse files of user"),
                 "usage": ["[user]"],
                 "aliases": ["b"],
-                "group": _("User")
+                "group": _("Users")
             },
 
         }
@@ -361,33 +360,39 @@ class Plugin(BasePlugin):
 
         if user is not None:
             command_list = self.parent.private_chat_commands
+            interface = "private_chat"  # _("_")
+            prefix = "/"
 
         elif room is not None:
             command_list = self.parent.chatroom_commands
+            interface = "chatroom"
+            prefix = "/"
 
         else:
             command_list = self.parent.cli_commands
+            interface = "cli"
+            prefix = ""
 
         query = args.split(" ", maxsplit=1)[0].lower().lstrip("/")
         command_groups = {}
         num_commands = 0
 
         for command, data in command_list.items():
-            command_message = command
+            command_message = command if prefix else command.lstrip("/")
             usage = " ".join(data.get("usage", []))
             aliases = data.get("aliases", [])
 
             if aliases:
-                command_message = command_message + " /" + " /".join(aliases)
+                command_message = command_message + f", {prefix}" + f", {prefix}".join(aliases)
 
             if usage:
                 command_message += " " + usage
 
             description = data.get("description", "No description")
-            group = data.get("group", _("Commands"))
-            group_words = group.lower().split(" ")
+            group = data.get("group", f"{self.config.application_name} {_('Commands')}")
+            group_words = group.lower()
 
-            if not args or query in command or query in (a for a in aliases) or query in group_words:
+            if not args or query in command_message or query in group_words:
                 if group not in command_groups:
                     command_groups[group] = []
 
@@ -395,19 +400,22 @@ class Plugin(BasePlugin):
                 num_commands += 1
 
         if not num_commands:
-            self.echo_unknown_command(query)
+            self.echo_unknown_command(f"{prefix}{query}")
+            return None
 
-        elif num_commands >= 2 and query:
-            self.echo_message("List of %i commands matching \"%s\":" % (num_commands, query))
+        output = f"Listing {num_commands} {interface} commands with <required> and [optional] arguments"
+        output += " " + f"matching \"{query}\"" + ":" if query else ":"
 
         for group, commands in command_groups.items():
-            self.echo_message("")
-            self.echo_message("  " + group + ":")
+            output += "\n\n" + "  " + group + ":"
 
             for command in commands:
-                self.echo_message(command)
+                output += "\n" + command
 
-        return ("To search for a command, type /help [command]")
+        output += "\n\n" + "Use /help [query] (without brackets) to find similar commands or aliases"
+        output += "\n" + "Start a command using / (forward slash)" if prefix else ""
+
+        return output
 
     """ "Chats" """
 
@@ -418,8 +426,6 @@ class Plugin(BasePlugin):
 
         elif user is not None:
             self.core.privatechats.clear_messages(user)
-
-        return 0
 
     def close_command(self, args, user=None, **_unused):
 
@@ -433,8 +439,6 @@ class Plugin(BasePlugin):
 
         self.core.privatechats.remove_user(user)
 
-        return 0
-
     def ctcpversion_command(self, args, user=None, **_unused):
 
         if args:
@@ -444,15 +448,15 @@ class Plugin(BasePlugin):
             user = self.core.login_username
 
         if self.send_private(user, self.core.privatechats.CTCP_VERSION, show_ui=False):
-            self.echo_message("Asked %s for client version" % user)
+            return "Asked %s for client version" % user
+
+        return False
 
     def hello_command(self, args, **_unused):
-        return ("Hello there! %s" % args)
+        return "Hello there! %s" % args
 
     def join_chat_command(self, args, **_unused):
         self.core.chatrooms.show_room(args)
-
-        return 0  # don't let a None echo steal the tab back again
 
     def leave_command(self, args, room=None, **_unused):
 
@@ -468,21 +472,19 @@ class Plugin(BasePlugin):
     def me_chat_command(self, args, **_unused):
         self.send_message("/me " + args)
 
-        return 0  # don't need any echo if we're chatting
-
     def msg_chat_command(self, args, **_unused):
 
         args_split = args.split(" ", maxsplit=1)
         user, text = args_split[0], args_split[1]
 
         if self.send_private(user, text, show_ui=True, switch_page=False):
-            return ("Private message sent to user %s" % user)
+            return "Private message sent to user %s" % user
+
+        return False
 
     def pm_chat_command(self, args, **_unused):
         self.core.privatechats.show_user(args)
-        self.log("Private chat with user %s" % args)
-
-        return 0  # don't let a None echo steal the tab back again (hence the use of log above instead of echo_message)
+        self.log("Private chat with user %s" % args)  # don't echo after switch_tab
 
     def say_chat_command(self, args, **_unused):
 
@@ -490,7 +492,9 @@ class Plugin(BasePlugin):
         room, text = args_split[0], args_split[1]
 
         if self.send_public(room, text):
-            return ("Chat message sent to room %s" % room)
+            return "Chat message sent to room %s" % room
+
+        return False
 
     """ "Shares" """
 
@@ -608,16 +612,14 @@ class Plugin(BasePlugin):
         if args:
             user = args
 
-        self.core.userinfo.request_user_info(user)  # TODO: returns None which blocks the switch tab
-        return 0
+        return self.core.userinfo.request_user_info(user)
 
     def browse_user_command(self, args, user=None, **_unused):
 
         if args:
             user = args
 
-        self.core.userbrowse.browse_user(user)  # TODO: returns None which blocks the switch tab
-        return 0
+        return self.core.userbrowse.browse_user(user)
 
     """ General "Commands" """
 

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -765,7 +765,7 @@ class PluginHandler:
                         output = getattr(plugin, data.get("callback").__name__)(args)
 
                     # For debug purposes, TODO: Consider if this would be a good way for functions to echo their output
-                    if output is 0:
+                    if output == 0:
                         # The command executed successfully and it wanted to consume the output entirely by itself,
                         # such as if it needed to switch a tab and a further echo would have switched it back again,
                         # or it is simply happy with no output or the output generated during its execution.

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -27,8 +27,9 @@ import pickle
 import shelve
 import stat
 import sys
-import threading
 import time
+
+from threading import Thread
 
 from pynicotine import slskmessages
 from pynicotine.logfacility import log
@@ -848,10 +849,9 @@ class Shares:
         scanner.start()
 
         if use_thread:
-            thread = threading.Thread(target=self._process_scanner, args=(scanner, scanner_queue))
-            thread.name = "ProcessShareScanner"
-            thread.daemon = True
-            thread.start()
+            Thread(
+                target=self._process_scanner, args=(scanner, scanner_queue), name="ProcessShareScanner", daemon=True
+            ).start()
             return None
 
         return self._process_scanner(scanner, scanner_queue)

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -31,6 +31,7 @@ server messages and p2p messages (between clients). """
 
 
 UINT_LIMIT = 4294967295
+UINT64_LIMIT = 18446744073709551615
 
 INT_UNPACK = struct.Struct("<i").unpack
 UINT_UNPACK = struct.Struct("<I").unpack

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -185,6 +185,8 @@ class SlskProtoThread(threading.Thread):
 
     IN_PROGRESS_STALE_AFTER = 2
     CONNECTION_MAX_IDLE = 60
+    READ_BUFFER_SIZE = 1048576
+    WRITE_BUFFER_SIZE = 1048576
 
     def __init__(self, core_callback, queue, bindip, interface, port, port_range):
         """ core_callback is a NicotineCore callback function to be called with messages
@@ -1091,6 +1093,8 @@ class SlskProtoThread(threading.Thread):
             conn_obj = ServerConnection(sock=server_socket, addr=msg_obj.addr, events=events, login=msg_obj.login)
 
             server_socket.setblocking(False)
+            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self.READ_BUFFER_SIZE)
+            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, self.WRITE_BUFFER_SIZE)
 
             # Detect if our connection to the server is still alive
             self.set_server_socket_keepalive(server_socket)
@@ -1445,6 +1449,8 @@ class SlskProtoThread(threading.Thread):
             conn_obj = PeerConnection(sock=sock, addr=msg_obj.addr, events=events, init=msg_obj.init)
 
             sock.setblocking(False)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self.READ_BUFFER_SIZE)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, self.WRITE_BUFFER_SIZE)
 
             if self.bindip:
                 sock.bind((self.bindip, 0))
@@ -2028,6 +2034,8 @@ class SlskProtoThread(threading.Thread):
 
         self.listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self.READ_BUFFER_SIZE)
+        self.listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, self.WRITE_BUFFER_SIZE)
         self.listen_socket.setblocking(False)
         self.bind_listen_port()
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -185,8 +185,8 @@ class SlskProtoThread(threading.Thread):
 
     IN_PROGRESS_STALE_AFTER = 2
     CONNECTION_MAX_IDLE = 60
-    READ_BUFFER_SIZE = 1048576
-    WRITE_BUFFER_SIZE = 1048576
+    SOCKET_READ_BUFFER_SIZE = 1048576
+    SOCKET_WRITE_BUFFER_SIZE = 1048576
 
     def __init__(self, core_callback, queue, bindip, interface, port, port_range):
         """ core_callback is a NicotineCore callback function to be called with messages
@@ -1093,8 +1093,8 @@ class SlskProtoThread(threading.Thread):
             conn_obj = ServerConnection(sock=server_socket, addr=msg_obj.addr, events=events, login=msg_obj.login)
 
             server_socket.setblocking(False)
-            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self.READ_BUFFER_SIZE)
-            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, self.WRITE_BUFFER_SIZE)
+            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self.SOCKET_READ_BUFFER_SIZE)
+            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, self.SOCKET_WRITE_BUFFER_SIZE)
 
             # Detect if our connection to the server is still alive
             self.set_server_socket_keepalive(server_socket)
@@ -1449,8 +1449,8 @@ class SlskProtoThread(threading.Thread):
             conn_obj = PeerConnection(sock=sock, addr=msg_obj.addr, events=events, init=msg_obj.init)
 
             sock.setblocking(False)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self.READ_BUFFER_SIZE)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, self.WRITE_BUFFER_SIZE)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self.SOCKET_READ_BUFFER_SIZE)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, self.SOCKET_WRITE_BUFFER_SIZE)
 
             if self.bindip:
                 sock.bind((self.bindip, 0))
@@ -2034,8 +2034,8 @@ class SlskProtoThread(threading.Thread):
 
         self.listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self.READ_BUFFER_SIZE)
-        self.listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, self.WRITE_BUFFER_SIZE)
+        self.listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self.SOCKET_READ_BUFFER_SIZE)
+        self.listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, self.SOCKET_WRITE_BUFFER_SIZE)
         self.listen_socket.setblocking(False)
         self.bind_listen_port()
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -949,7 +949,7 @@ class SlskProtoThread(threading.Thread):
 
             if callback:
                 self._callback_msgs.append(DownloadConnectionClosed(
-                    user=init.target_user, token=conn_obj.fileinit.token
+                    user=init.target_user, token=conn_obj.filedown.token
                 ))
 
             self._calc_download_limit()
@@ -963,7 +963,7 @@ class SlskProtoThread(threading.Thread):
             if callback:
                 timed_out = (time.time() - conn_obj.lastactive) > self.CONNECTION_MAX_IDLE
                 self._callback_msgs.append(UploadConnectionClosed(
-                    user=init.target_user, token=conn_obj.fileinit.token, timed_out=timed_out
+                    user=init.target_user, token=conn_obj.fileupl.token, timed_out=timed_out
                 ))
 
             self._calc_upload_limit_function()

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -33,13 +33,13 @@ import os
 import os.path
 import re
 import stat
-import threading
 import time
 
 from collections import defaultdict
 from collections import deque
 from collections import OrderedDict
 from operator import itemgetter
+from threading import Thread
 
 from pynicotine import slskmessages
 from pynicotine.logfacility import log
@@ -150,22 +150,13 @@ class Transfers:
         self.watch_stored_downloads()
 
         # Check for transfer timeouts
-        thread = threading.Thread(target=self._check_transfer_timeouts)
-        thread.name = "TransferTimeoutTimer"
-        thread.daemon = True
-        thread.start()
+        Thread(target=self._check_transfer_timeouts, name="TransferTimeoutTimer", daemon=True).start()
 
         # Check for failed downloads (1 min delay)
-        thread = threading.Thread(target=self._check_download_queue_timer)
-        thread.name = "DownloadQueueTimer"
-        thread.daemon = True
-        thread.start()
+        Thread(target=self._check_download_queue_timer, name="DownloadQueueTimer", daemon=True).start()
 
         # Check if queued uploads can be started
-        thread = threading.Thread(target=self._check_upload_queue_timer)
-        thread.name = "UploadQueueTimer"
-        thread.daemon = True
-        thread.start()
+        Thread(target=self._check_upload_queue_timer, name="UploadQueueTimer", daemon=True).start()
 
         if self.downloadsview:
             self.downloadsview.server_login()

--- a/pynicotine/upnp.py
+++ b/pynicotine/upnp.py
@@ -16,8 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import threading
 import socket
+
+from threading import Thread
+from threading import Timer
 
 from pynicotine.config import config
 from pynicotine.logfacility import log
@@ -382,10 +384,7 @@ class UPnP:
         if blocking:
             self._update_port_mapping()
         else:
-            thread = threading.Thread(target=self._update_port_mapping)
-            thread.name = "UPnPAddPortmapping"
-            thread.daemon = True
-            thread.start()
+            Thread(target=self._update_port_mapping, name="UPnPAddPortmapping", daemon=True).start()
 
         # Repeat
         self._start_timer()
@@ -402,7 +401,7 @@ class UPnP:
 
         upnp_interval_seconds = upnp_interval * 60 * 60
 
-        self.timer = threading.Timer(upnp_interval_seconds, self.add_port_mapping)
+        self.timer = Timer(interval=upnp_interval_seconds, function=self.add_port_mapping)
         self.timer.name = "UPnPTimer"
         self.timer.daemon = True
         self.timer.start()

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -18,9 +18,9 @@
 
 import json
 import os
-import threading
 
 from operator import itemgetter
+from threading import Thread
 
 from pynicotine import slskmessages
 from pynicotine import utils
@@ -91,10 +91,9 @@ class UserBrowse:
 
         if username not in self.users or new_request:
             msg = self.core.shares.get_compressed_shares_message("normal")
-            thread = threading.Thread(target=self.parse_local_shares, args=(username, msg))
-            thread.name = "LocalShareParser"
-            thread.daemon = True
-            thread.start()
+            Thread(
+                target=self.parse_local_shares, args=(username, msg), name="LocalShareParser", daemon=True
+            ).start()
 
         self.show_user(username, path=path, local_shares_type="normal")
 
@@ -105,10 +104,9 @@ class UserBrowse:
 
         if username not in self.users or new_request:
             msg = self.core.shares.get_compressed_shares_message("buddy")
-            thread = threading.Thread(target=self.parse_local_shares, args=(username, msg))
-            thread.name = "LocalBuddyShareParser"
-            thread.daemon = True
-            thread.start()
+            Thread(
+                target=self.parse_local_shares, args=(username, msg), name="LocalBuddyShareParser", daemon=True
+            ).start()
 
         self.show_user(username, path=path, local_shares_type="buddy")
 

--- a/test/integration/test_startup.py
+++ b/test/integration/test_startup.py
@@ -52,7 +52,7 @@ class StartupTest(unittest.TestCase):
         """ Verify that CLI-exclusive functionality works """
 
         output = subprocess.check_output(["python3", "-m", "pynicotine", "--help"], timeout=3)
-        self.assertTrue(str(output).find("--help") > -1)
+        self.assertIn("--help", str(output))
 
         # Check for " 0 folders found after rescan" in output. Text strings are translatable,
         # so we can't match them directly.
@@ -60,7 +60,7 @@ class StartupTest(unittest.TestCase):
             ["python3", "-m", "pynicotine", "--config=" + CONFIG_FILE, "--user-data=" + USER_DATA, "--rescan"],
             timeout=10
         )
-        self.assertTrue(str(output).find(" 0 ") > -1)
+        self.assertIn(" 0 ", str(output))
 
         output = subprocess.check_output(["python3", "-m", "pynicotine", "--version"], timeout=3)
-        self.assertTrue(str(output).find("Nicotine+") > -1)
+        self.assertIn("Nicotine+", str(output))

--- a/test/integration/test_startup.py
+++ b/test/integration/test_startup.py
@@ -18,6 +18,7 @@
 
 import os
 import subprocess
+import sys
 import unittest
 
 USER_DATA = os.path.dirname(os.path.realpath(__file__))
@@ -48,6 +49,7 @@ class StartupTest(unittest.TestCase):
 
             self.assertTrue(is_success)
 
+    @unittest.skipIf((sys.platform == "win32"), "CLI tests are currently flaky in Windows CI")
     def test_cli(self):
         """ Verify that CLI-exclusive functionality works """
 

--- a/test/unit/protocol/test_slskproto.py
+++ b/test/unit/protocol/test_slskproto.py
@@ -105,11 +105,11 @@ class SlskProtoTest(unittest.TestCase):
         sleep(SLSKPROTO_RUN_TIME)
 
         if hasattr(socket, 'TCP_KEEPIDLE') or hasattr(socket, 'TCP_KEEPALIVE'):
-            self.assertEqual(self.protothread.server_socket.setsockopt.call_count, 4)  # pylint: disable=no-member
+            self.assertEqual(self.protothread.server_socket.setsockopt.call_count, 6)  # pylint: disable=no-member
 
         elif hasattr(socket, 'SIO_KEEPALIVE_VALS'):
             self.assertEqual(self.protothread.server_socket.ioctl.call_count, 1)       # pylint: disable=no-member
-            self.assertEqual(self.protothread.server_socket.setsockopt.call_count, 1)  # pylint: disable=no-member
+            self.assertEqual(self.protothread.server_socket.setsockopt.call_count, 3)  # pylint: disable=no-member
 
         self.assertEqual(self.protothread.server_socket.setblocking.call_count, 1)     # pylint: disable=no-member
         self.assertEqual(self.protothread.server_socket.connect_ex.call_count, 1)      # pylint: disable=no-member


### PR DESCRIPTION
_Note: Updated to master_

+ Added: Echo the input command line ala pseudo-terminal.
+ Added: parse_command_arguments() in pluginsystem to check and prompt for missing required arguments or incorrect options
+ Added: The source TextEntry widget retains the command line and selects all if the line is rejected by the parser or if the plugin command returns False.
- Removed: Timestamps from echo, and changed private chats echo_message() to action style to match chat rooms, this seems to be more in the spirit of the vintage clients, whereby it is only the actual chat log that have timestamps.
+ Added: Optional -`force` flag argument for the rescan command (the hyphen doesn't need to be typed in the line) - force rescan and list shares is not implemented in this branch, it's only here for testing the flag argument parsing.

These commands highlight that modifications to the core are required to provide useful ~echo~ returns ~without having to generate strings within the plugin itself~. (_edited: We just want True or False returns from the core_)**