### PR TITLE
pluginsystem.py: input command line echo in chat

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -940,8 +940,12 @@ class ChatRoom:
 
     def echo_message(self, text, message_type):
 
+        if message_type == "echo":
+            timestamp_format = None
+        else:
+            timestamp_format = config.sections["logging"]["rooms_timestamp"]
+
         tag = self.tag_action
-        timestamp_format = config.sections["logging"]["rooms_timestamp"]
 
         if hasattr(self, "tag_" + str(message_type)):
             tag = getattr(self, "tag_" + str(message_type))

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -440,8 +440,12 @@ class PrivateChat:
 
     def echo_message(self, text, message_type):
 
-        tag = self.tag_local
-        timestamp_format = config.sections["logging"]["private_timestamp"]
+        if message_type == "echo":
+            timestamp_format = None
+            tag = self.tag_action
+        else:
+            timestamp_format = config.sections["logging"]["private_timestamp"]
+            tag = self.tag_local
 
         if hasattr(self, "tag_" + str(message_type)):
             tag = getattr(self, "tag_" + str(message_type))

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -104,19 +104,23 @@ class ChatEntry:
         cmd_split = text.split(maxsplit=1)
         cmd = cmd_split[0]
 
-        # Clear chat entry
-        self.entry.set_text("")
-
         if len(cmd_split) == 2:
             args = cmd_split[1]
         else:
             args = ""
 
+        # Allow the command line to be edited if parsing rejects the line or if the plugin returns False
         if self.is_chatroom:
-            self.core.pluginhandler.trigger_chatroom_command_event(self.entity, cmd[1:], args)
+            if not self.core.pluginhandler.trigger_chatroom_command_event(self.entity, cmd[1:], args):
+                self.entry.grab_focus()
+                return
+
+        elif not self.core.pluginhandler.trigger_private_chat_command_event(self.entity, cmd[1:], args):
+            self.entry.grab_focus()
             return
 
-        self.core.pluginhandler.trigger_private_chat_command_event(self.entity, cmd[1:], args)
+        # Clear chat entry
+        self.entry.set_text("")
 
     def on_tab_complete_accelerator(self, widget, state, backwards=False):
         """ Tab and Shift+Tab: tab complete chat """

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -229,12 +229,13 @@ class Plugin(BasePlugin):
         if args:
             user = args
 
-        if user in self.core.privatechats.users:
-            self.echo_message("Closing private chat of user %s" % user)
-        elif user:
+        if user not in self.core.privatechats.users:
             self.echo_message("Not messaging with user %s" % user)
+            return False
 
+        self.echo_message("Closing private chat of user %s" % user)
         self.core.privatechats.remove_user(user)
+        return True
 
     def ctcpversion_command(self, args, user=None, **_unused):
 
@@ -260,9 +261,10 @@ class Plugin(BasePlugin):
 
         if room not in self.core.chatrooms.joined_rooms:
             self.echo_message("Not joined in room %s" % room)
-            # return  # in future the gui might need to close a tab even if we are not joined, such as while offline etc
+            return False
 
         self.core.chatrooms.remove_room(room)
+        return True
 
     def me_chat_command(self, args, **_unused):
         self.send_message("/me " + args)
@@ -273,7 +275,9 @@ class Plugin(BasePlugin):
         user, text = args_split[0], args_split[1]
 
         if self.send_private(user, text, show_ui=True, switch_page=False):
-            self.echo_message("Private message sent to user %s" % user)
+            return "Private message sent to user %s" % user
+
+        return False
 
     def pm_chat_command(self, args, **_unused):
         self.core.privatechats.show_user(args)
@@ -285,7 +289,9 @@ class Plugin(BasePlugin):
         room, text = args_split[0], args_split[1]
 
         if self.send_public(room, text):
-            self.log("Chat message sent to room %s" % room)
+            return "Chat message sent to room %s" % room
+
+        return False
 
     def add_share_command(self, args):
 

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -716,12 +716,19 @@ class PluginHandler:
 
             if room is not None:
                 commands = plugin.chatroom_commands
+                prefix = "/"
 
             elif user is not None:
                 commands = plugin.private_chat_commands
+                prefix = "/"
 
             else:
                 commands = plugin.cli_commands
+                prefix = ""
+
+            if prefix:
+                # Input command line echo is needed in chat view
+                plugin.echo_message(f"{prefix}{command} {args}")
 
             try:
                 for trigger, data in commands.items():

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -224,7 +224,7 @@ class BasePlugin:
         function = self.send_public if command_type == "chatroom" else self.send_private
         return function(source, text)
 
-    def echo_message(self, text, message_type="local"):
+    def echo_message(self, text, message_type="echo"):
         """ Convenience function to display a raw message the same window
         a plugin command runs from """
 


### PR DESCRIPTION
+ Added: Echo the input command line in chat, as would ordinarily be expected like a pseudo terminal
+ Added: Highlight a rejected input in the TextEntry, instead of clearing it, (say for instance a mistyped room name or command)
+ Removed: Timestamps from echo messages, to make the command inputs and outputs easily identifiable from the chat log
- Changed: Private chat echo style tag to "action" instead of "local" to match chat rooms (unsure as to why private chats has a different default tag style for echo_message)